### PR TITLE
Fix check for installed version with no install

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -211,7 +211,7 @@ SKIP_DOWNLOAD="no"
 # Installed version detection (only supported for deb based systems, feel free to submit rpm equivalent)
 if [ "${REDHAT}" != "yes" ]; then
 	INSTALLED_VERSION=$(dpkg-query -s plexmediaserver 2>/dev/null | grep -Po 'Version: \K.*')
-	if [[ $FILENAME == *$INSTALLED_VERSION* ]] && [ "${FORCE}" != "yes" ]; then
+	if [[ $FILENAME == *$INSTALLED_VERSION* ]] && [ "${FORCE}" != "yes" ] && [ ! -z "${INSTALLED_VERSION}" ]; then
 		echo "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
 		exit 5
 	fi


### PR DESCRIPTION
I want to use this script for a vagrant script I'm building, so I'd like it to install a fresh copy of Plex if one is not currently installed, or get the latest version on a re-provision.

When plexmediaserver is not installed, the version check fails (or always matches).  This pull request checks the installed version to make sure it's not blank.  If it is blank, force it to download the latest version.