### PR TITLE
Download Directory fix for multiple spaces

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -133,7 +133,7 @@ fi
 
 
 # Remove any ~ or other oddness in the path we're given
-DOWNLOADDIR="$(eval cd ${DOWNLOADDIR/ /\\ } ; if [ $? -eq 0 ]; then pwd; fi)"
+DOWNLOADDIR="$(eval cd ${DOWNLOADDIR// /\\ } ; if [ $? -eq 0 ]; then pwd; fi)"
 if [ -z "${DOWNLOADDIR}" ]; then
 	echo "Error: Download directory does not exist or is not a directory"
 	exit 1


### PR DESCRIPTION
I was still getting an error because only the first space in my DOWNLOADDIR was getting replaced.  Adding the other / tells the expansion to match all occurrences.  Found that here http://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html