### PR TITLE
yum localinstall is deprecated, install will handle local files as well.

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -289,7 +289,7 @@ fi
 
 if [ "${AUTOINSTALL}" == "yes" ]; then
 	if [ "${REDHAT}" == "yes" ]; then
-		sudo yum -y localinstall "${DOWNLOADDIR}/${FILENAME}"
+		sudo yum -y install "${DOWNLOADDIR}/${FILENAME}"
 	else
 		sudo dpkg -i "${DOWNLOADDIR}/${FILENAME}"
 	fi


### PR DESCRIPTION
What's more, in newer versions of fedora (and eventually in redhat/centos) yum is superceded by dnf, which doesn't have the localinstall option. It only supports install. Yum in these versions passes all commands on to dnf, so using yum localinstall in these versions throws an error. Because older versions of yum allow install to do localinstalls, this seems like the best middle ground.