### PR TITLE
Added systemd support for AUTOSTART

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -321,10 +321,12 @@ if [ "${AUTOSTART}" == "yes" ]; then
 	elif [ "${REDHAT}" == "no" ]; then
 		echo "The AUTOSTART [-s] option may not be needed on your distribution."
 	fi
+	
+	# Check for systemd
 	if [ -f "/bin/systemctl" ]; then
-		sudo systemctl start plexmediaserver.service
+		systemctl start plexmediaserver.service
 	else
-		sudo service plexmediaserver start
+		service plexmediaserver start
 	fi
 fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -321,7 +321,11 @@ if [ "${AUTOSTART}" == "yes" ]; then
 	elif [ "${REDHAT}" == "no" ]; then
 		echo "The AUTOSTART [-s] option may not be needed on your distribution."
 	fi
-	sudo service plexmediaserver start
+	if [ -f "/bin/systemctl" ]; then
+		sudo systemctl start plexmediaserver.service
+	else
+		sudo service plexmediaserver start
+	fi
 fi
 
 exit 0


### PR DESCRIPTION
This will simply check for systemctl, if it's there, you're probably using systemd. If it's not, you're probably still on sysvinit. This way the service will appropriately get restarted. As on RHEL/CentOS 7 & Ubuntu 15.10, systemd is now the default.