### PR TITLE
Added systemd support to AUTOSTART

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -317,7 +317,12 @@ if [ "${AUTOSTART}" == "yes" ]; then
 	if [ "${REDHAT}" == "no" ]; then
 		echo "The AUTOSTART [-s] option may not be needed on your distribution."
 	fi
-	service plexmediaserver start
+	# Check for systemd
+	if [ -f "/bin/systemctl" ]; then
+		systemctl start plexmediaserver.service
+	else
+		service plexmediaserver start
+	fi
 fi
 
 exit 0


### PR DESCRIPTION
This will simply check for systemctl, if it's there, you're probably using systemd. If it's not, you're probably still on sysvinit. This way the service will appropriately get restarted. As on RHEL/CentOS 7 & Ubuntu 15.10, systemd is now the default.

Too late, just deleted the repo and redid the change. Refer to pr 30. I didn't have a box handy to do the pull to. Edited it all in the browser.