### PR TITLE
made root check case-insensitive

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -141,7 +141,7 @@ if [ "${EMAIL}" == "" -o "${PASS}" == "" ] && [ "${PUBLIC}" == "no" ]; then
 fi
 
 if [ "${AUTOINSTALL}" == "yes" -o "${AUTOSTART}" == "yes" ]; then
-	id | grep 'uid=0(' 2>&1 >/dev/null
+	id | grep -i 'uid=0(' 2>&1 >/dev/null
 	if [ $? -ne 0 ]; then
 		echo "Error: You need to be root to use autoinstall/autostart option."
 		exit 1


### PR DESCRIPTION
running the script via sudo, kept returning the 'run as root' error.
Reason: id returned 'UID=0(root) GID=0(root) groepen=0(root)', while the lower case version was expected