### PR TITLE
Use absolute path to /sbin/service

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -345,7 +345,7 @@ if [ "${AUTOSTART}" == "yes" ]; then
 	if [ -f "/bin/systemctl" ]; then
 		systemctl start plexmediaserver.service
 	else
-		service plexmediaserver start
+		/sbin/service plexmediaserver start
 	fi
 fi
 


### PR DESCRIPTION
Sometimes, when using sudo or cron, /sbin might not be in the user's PATH, and thus we need to specify its full path when AUTOSTARTing it.