### PR TITLE
Allow script to run with sudo

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -65,8 +65,12 @@ if [ $? -eq 127 ]; then
 fi
 
 # Load settings from config file if it exists
-if [ -f ~/.plexupdate ]; then
-	source ~/.plexupdate
+CONFIG_FILE="${HOME}/.plexupdate"
+if [[ ! -z ${SUDO_USER} ]] ; then
+	CONFIG_FILE="`eval echo ~${SUDO_USER}`/.plexupdate"
+fi
+if [ -f ${CONFIG_FILE} ]; then
+	source ${CONFIG_FILE}
 fi
 
 if [ "${RELEASE}" = "64-bit" ]; then


### PR DESCRIPTION
Load .plexupdate file from the user's home folder, instead of /root/, when script is executed using sudo.
Fixes #38