### PR TITLE
add option -r to print the download url and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ There are a few other options for the more enterprising user. Setting any of the
   The default behavior of plexupdate.sh is to download the PlexPass edition of Plex Media Center. Setting this option to `yes` will make it download the public version instead. If this is yes, then `EMAIL` and `PASS` is no longer needed.
 - FORCE 
   Normally plexupdate.sh will avoid downloading a file it already has or if it's the same as the installed version, but this allows you to override.
+- PRINT_URL
+  Authenticate, fetch the download URL, print it, and then exit.
 
 Most of these options can be specified on the command-line as well, this is just a more convenient way of doing it if you're scripting it. Which brings us to...
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -87,11 +87,11 @@ URL_DOWNLOAD_PUBLIC=https://plex.tv/downloads
 
 # Parse commandline
 ALLARGS="$@"
-set -- $(getopt aufhko: -- "$@")
+set -- $(getopt aufhkro: -- "$@")
 while true;
 do
 	case "$1" in
-	(-h) echo -e "Usage: $(basename $0) [-afhkopsuU]\n\na = Auto install if download was successful (requires root)\nd = Auto delete after auto install\nf = Force download even if it's the same version or file already exists (WILL NOT OVERWRITE)\nh = This help\nk = Reuse last authentication\no = 32-bit version (default 64 bit)\np = Public Plex Media Server version\nu = Auto update plexupdate.sh before running it (experimental)\nU = Do not autoupdate plexupdate.sh (experimental, default)\ns = Auto start (needed for some distros)\n"; exit 0;;
+	(-h) echo -e "Usage: $(basename $0) [-afhkopsuU]\n\na = Auto install if download was successful (requires root)\nd = Auto delete after auto install\nf = Force download even if it's the same version or file already exists (WILL NOT OVERWRITE)\nh = This help\nk = Reuse last authentication\no = 32-bit version (default 64 bit)\np = Public Plex Media Server version\nu = Auto update plexupdate.sh before running it (experimental)\nU = Do not autoupdate plexupdate.sh (experimental, default)\ns = Auto start (needed for some distros)\np = Print download URL and exit\n"; exit 0;;
 	(-a) AUTOINSTALL=yes;;
 	(-d) AUTODELETE=yes;;
 	(-f) FORCE=yes;;
@@ -101,6 +101,7 @@ do
 	(-u) AUTOUPDATE=yes;;
 	(-U) AUTOUPDATE=no;;
 	(-s) AUTOSTART=yes;;
+	(-r) PRINT_URL=yes;;
 	(--) ;;
 	(-*) echo "Error: unrecognized option $1" 1>&2; exit 1;;
 	(*)  break;;
@@ -278,6 +279,11 @@ FILENAME="$(basename 2>/dev/null ${DOWNLOAD})"
 if [ $? -ne 0 ]; then
 	echo "Failed to parse HTML, download cancelled."
 	exit 3
+fi
+
+if [ "${PRINT_URL}" == "yes" ]; then
+  echo "${DOWNLOAD}"
+  exit 0
 fi
 
 # By default, try downloading


### PR DESCRIPTION
This option is useful when all you need is to resolve the plex pass download url and then use it in another installation process.

```
$ ./plexupdate.sh -r | tail -1
http:// ....
```