### PR TITLE
Fix KEEP option

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -151,8 +151,8 @@ if [ "${AUTOUPDATE}" == "yes" ]; then
 fi
 
 # Sanity check
-if [ "${EMAIL}" == "" -o "${PASS}" == "" ] && [ "${PUBLIC}" == "no" ]; then
-	echo "Error: Need username & password to download PlexPass version. Otherwise run with -p to download public version."
+if [ "${EMAIL}" == "" -o "${PASS}" == "" ] && [ "${PUBLIC}" == "no" ] && [ ! -f /tmp/kaka ]; then
+	echo "Error: Need username & password or -k optoin to download PlexPass version. Otherwise run with -p to download public version."
 	exit 1
 fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -152,7 +152,7 @@ fi
 
 # Sanity check
 if [ "${EMAIL}" == "" -o "${PASS}" == "" ] && [ "${PUBLIC}" == "no" ] && [ ! -f /tmp/kaka ]; then
-	echo "Error: Need username & password or -k optoin to download PlexPass version. Otherwise run with -p to download public version."
+	echo "Error: Need username & password or -k option to download PlexPass version. Otherwise run with -p to download public version."
 	exit 1
 fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -263,7 +263,7 @@ if [ "${KEEP}" != "yes" -o ! -f /tmp/kaka ] && [ "${PUBLIC}" == "no" ]; then
 		exit 1
 	fi
 	echo "OK"
-else
+elif [ "$PUBLIC" != "no" ]; then
 	# It's a public version, so change URL and make doubly sure that cookies are empty
 	rm 2>/dev/null >/dev/null /tmp/kaka
 	touch /tmp/kaka


### PR DESCRIPTION
This fixes both the problem where `KEEP` would still be ignored (due to the `PUBLIC` option), and the requirement that `EMAIL`/`PASS` be specified even if we have saved credentials from a previous `KEEP` run.

Closes mrworf/plexupdate#52