### PR TITLE
Cron mode should not exit with non-zero if up to date

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -372,8 +372,9 @@ fi
 if [[ $FILENAME == *$INSTALLED_VERSION* ]] && [ "${FORCE}" != "yes" ] && [ ! -z "${INSTALLED_VERSION}" ]; then
         if [ "${CRON}" = "no" ]; then
 	        echo "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
+	        exit 5
         fi
-	exit 5
+	exit 0
 fi
 
 if [ -f "${DOWNLOADDIR}/${FILENAME}" -a "${FORCE}" != "yes" ]; then


### PR DESCRIPTION
If plex is up to date, cron mode should exit with 0.