### PR TITLE
Fix for token issue

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -302,6 +302,9 @@ if [ "${KEEP}" != "yes" -o ! -f /tmp/kaka ] && [ "${PUBLIC}" == "no" ]; then
 		cat /tmp/failcause >&2
 		exit 1
 	fi
+	
+	# If the system got here, it means the login was successfull, so we set the TOKEN variable to the authToken from the response
+	# I use cut -c 14- to cut off the "authToken":" string from the grepped result, can probably be done in a different way
 	TOKEN=$(</tmp/failcause  grep -ioe '"authToken":"[^"]*' | cut -c 14-)
 
 	# Remove this, since it contains more information than we should leave hanging around
@@ -343,6 +346,7 @@ if [ "${CRON}" = "no" ]; then
         echo -n "Finding download URL to download..."
 fi
 
+# Set "X-Plex-Token" to the auth token, if no token is specified or it is invalid, the list will return public downloads by default
 DOWNLOAD=$(wget --header "X-Plex-Token:"${TOKEN}"" --load-cookies /tmp/kaka --save-cookies /tmp/kaka --keep-session-cookies "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -ioe '"label"[^}]*' | grep -i "\"distro\":\"${DISTRO}\"" | grep -i "\"build\":\"${BUILD}\"" | grep -m1 -ioe 'https://[^\"]*' )
 
 if [ "${CRON}" = "no" ]; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -302,6 +302,8 @@ if [ "${KEEP}" != "yes" -o ! -f /tmp/kaka ] && [ "${PUBLIC}" == "no" ]; then
 		cat /tmp/failcause >&2
 		exit 1
 	fi
+	TOKEN=$(</tmp/failcause  grep -ioe '"authToken":"[^"]*' | cut -c 14-)
+
 	# Remove this, since it contains more information than we should leave hanging around
 	rm /tmp/failcause
 
@@ -341,7 +343,8 @@ if [ "${CRON}" = "no" ]; then
         echo -n "Finding download URL to download..."
 fi
 
-DOWNLOAD=$(wget --load-cookies /tmp/kaka --save-cookies /tmp/kaka --keep-session-cookies "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -ioe '"label"[^}]*' | grep -i "\"distro\":\"${DISTRO}\"" | grep -i "\"build\":\"${BUILD}\"" | grep -m1 -ioe 'https://[^\"]*' )
+DOWNLOAD=$(wget --header "X-Plex-Token:"${TOKEN}"" --load-cookies /tmp/kaka --save-cookies /tmp/kaka --keep-session-cookies "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -ioe '"label"[^}]*' | grep -i "\"distro\":\"${DISTRO}\"" | grep -i "\"build\":\"${BUILD}\"" | grep -m1 -ioe 'https://[^\"]*' )
+
 if [ "${CRON}" = "no" ]; then
         echo -e "OK"
 fi


### PR DESCRIPTION
It seems that Plex changed how you can access their Plexpass download channels. This fix gets the token from the Sign in response, and sets it as a token in the download request.

It can probably be optimised or be done different, but this is just a quick fix (which works for me)

This should fix #68 