### PR TITLE
Change Exit Code with Cron mode

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -384,9 +384,8 @@ fi
 if [[ $FILENAME == *$INSTALLED_VERSION* ]] && [ "${FORCE}" != "yes" ] && [ ! -z "${INSTALLED_VERSION}" ]; then
         if [ "${CRON}" = "no" ]; then
 	        echo "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
-	        exit 5
-        fi
-	exit 0
+	fi
+	exit 5
 fi
 
 if [ -f "${DOWNLOADDIR}/${FILENAME}" -a "${FORCE}" != "yes" ]; then


### PR DESCRIPTION
I was using the plexupdate.sh in another script to notify me with pushover after the Update. I've set up different notifications based on different exit codes and I was wondering about getting success-installation notifications even though there was no new update. Basically the updatescript is exiting with code 5 when there is no new version (except you force it to install) but only if you dont use the -C option / Cron mode. Else it was just exiting with code 0 there.