### PR TITLE
Add Telegram Notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ There are also a few additional options for the more enterprising user. Setting 
   NOTE! If you define this, you MUST define DISTRO and BUILD
 - DISTRO and BUILD
   Override which version to download, use -l option to see what you can select.
+- TELEGRAM_NOTIFY
+  Enable Telegram notification support. Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID
+- TELEGRAM_BOT_TOKEN
+  After talking to BotFather and creating a new bot, you can acquire the Bot Token required for the Telegram API.
+- TELEGRAM_CHAT_ID
+  Ask myidbot for your chat ID, or your group's chat ID, required for the Telegram API.
+- TELEGRAM_DEBUG
+  Output API messages for debugging. 
 
 Most of these options can be specified on the command-line as well, this is just a more convenient way of doing it if you're scripting it. Which brings us to...
 


### PR DESCRIPTION
I worked on this a little tonight.

Added option for -t which turns TELEGRAM_NOTIFY=yes
Telegram requires BOT_TOKEN and CHAT_ID in order to send. These come from BotFather and myidbot, respectively. 
- BotFather helps you create bots and provides token IDs.  See /newbot for new bots and /token for retrieving a known token.
- myidbot can help you find your personal chat ID or the chat ID of a group. See /getid in a direct message to myidbot, or invite myidbot to your group and ask /getgroupid@mybotid

Currently, only sends message to you if successful. Didn't know if wanted to add more code in at this time to enhance PLEXSERVER responses as well.

TELEGRAM_DEBUG set to yes will output the API response from Telegram. Otherwise, simple notification. 