### PR TITLE
Fix to allow combined command-line options

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -165,7 +165,12 @@ usage() {
 
 # Parse commandline
 ALLARGS=( "$@" )
-set -- $(getopt acCdfhkopqruU: -- "$@")
+optstring="acCdfhkopqruU"
+getopt -T >/dev/null
+if [ $? -eq 4 ]; then
+	optstring="-o $optstring"
+fi
+set -- $(getopt $optstring -- "$@")
 while true;
 do
 	case "$1" in


### PR DESCRIPTION
Due to a feature/bug in getopt, calling plexupdate.sh with concatenated
options (e.g. `plexupdate.sh -cq`), causes an error even though modern
versions of getopt have support for that format. The culprit seems to be
the "getopt compatibility mode". With these changes, a modern
implementation of getopt will work correctly with more complex options,
while old versions will continue to work as they currently do (requiring
multiple options to be given independently e.g. `plexupdate.sh -c -q`)

I also removed the `:` from the end of the options string since with the new "fixed" parsing, it would correctly throw an error if `-U` wasn't followed by an argument.