### PR TITLE
Add missing options and remove nonexistent ones

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -165,7 +165,7 @@ usage() {
 
 # Parse commandline
 ALLARGS=( "$@" )
-optstring="acCdfhkopqrsuU"
+optstring="acCdfhlpqrSsuU"
 getopt -T >/dev/null
 if [ $? -eq 4 ]; then
 	optstring="-o $optstring"


### PR DESCRIPTION
It looks like the options string has never really been properly checked since
compatibility mode just allows any undefined options through quietly and never
really throws errors.

With the recent switch to enable multiple options, this broke "l", "S" and "s".
This fixes "l" and "S" while also removing "k" and "o" which look like they
were never actually used anyway. ("s" was fixed in #82 earlier)