### PR TITLE
Make -c useful again

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@ It's fairly easy, but let's take it step by step (if it seems too much, skip to 
 
 ####Using wget and unzip
 
-You can either download it as a [zip file](https://github.com/mrworf/plexupdate/archive/master.zip) and unzip it on your server.
+Download it as a [zip file](https://github.com/mrworf/plexupdate/archive/master.zip) and unzip it on your server.
 ```
 wget https://github.com/mrworf/plexupdate/archive/master.zip && unzip master.zip && mv plexupdate-master plexupdate && rm master.zip
 ```
 Note that unzip is requered (`sudo apt-get install unzip`).
 
 ####Using git to clone (Recommended)
-Using git is way eaiser and recommended, if you ask me. 
+Using git is way easier and recommended, if you ask me. 
 ```
 git clone https://github.com/mrworf/plexupdate.git
 ```
 Note that git is requered (`sudo apt-get install git-all`)
 
-The main benefit with git clone is that you can update to latest version very easily. *Said in another way*: Auto update only works, if you've done a git clone.
+The main benefit with git clone is that you can update to latest version very easily. If you want to use the auto update feature, you must be using a git clone.
 
 ## 2. Setting it up
 
 plexupdate.sh looks for a file named `.plexupdate` located in your home directory. Please note that I'm referring to the home directory of the user who is running the plexupdate.sh ... If that user is someone else (root for instance) you'll need to make sure that user has the config file set up properly as well.
 
-The contents of this file usually is
+The contents of this file are usually:
 
 ```
 EMAIL="my.email@plex-server.com"
@@ -40,16 +40,16 @@ PASS="my-secret-plex-password"
 DOWNLOADDIR="/a/folder/to/save/the/files/in"
 ```
 
-Obviously you need to change these three so they match your account information. And if you don't put anything as a `DOWNLOADDIR`, the tool will use the folder you're executing the script from. So take care.
+Obviously you need to change these so they match your account information. And if you don't put anything as a `DOWNLOADDIR`, the tool will use the folder you're executing the script from. So take care.
 
 ## 3. Advanced options
 
-You can point out a different file than ```.plexupdate``` by providing it as the last argument to the script. It HAS to be the LAST argument, or it will be ignored. Any options set by the config file can be overriden with commandline options.
+You can point out a different file than ```.plexupdate``` by providing it as the last argument to the script. It HAS to be the LAST argument, or it will be ignored. Any options set by the config file can be overriden with command-line options.
 
 There are also a few additional options for the more enterprising user. Setting any of these to `yes` will enable the function.
 
 - PLEXSERVER
-  If set, and combined with AUTOINSTALL, the script will automatically check if server is in-use and deferr the update. Great for crontab users. PLEXSERVER should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
+  If set, and combined with AUTOINSTALL, the script will automatically check if the server is in-use and deferr the update. Great for crontab users. PLEXSERVER should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
 - AUTOUPDATE
   Makes plexupdate.sh automatically update itself using git. Note! This will fail if git isn't available on the command line.
 - AUTOINSTALL
@@ -59,11 +59,11 @@ There are also a few additional options for the more enterprising user. Setting 
 - PUBLIC 
   The default behavior of plexupdate.sh is to download the PlexPass edition of Plex Media Center. Setting this option to `yes` will make it download the public version instead. If this is yes, then `EMAIL` and `PASS` is no longer needed.
 - FORCE 
-  Normally plexupdate.sh will avoid downloading a file it already has or if it's the same as the installed version, but this allows you to override.
+  Normally plexupdate.sh will avoid downloading a file it already has or if it's the same as the installed version. Using this option will force it to download again and, if you have AUTOINSTALL set, reinstall it.
 - PRINT_URL
   Authenticate, fetch the download URL, print it, and then exit.
 - DISTRO_INSTALL
-  The commandline used to install packages, only change if you need special options. Natively supports Debian and Redhat, so need to set this for these systems.
+  The command used to install packages, only change if you need special options. Natively supports Debian and Redhat, so you don't need to set this for these systems.
   NOTE! If you define this, you MUST define DISTRO and BUILD
 - DISTRO and BUILD
   Override which version to download, use -l option to see what you can select.
@@ -72,15 +72,9 @@ Most of these options can be specified on the command-line as well, this is just
 
 ### Using it from CRON
 
-It seems quite popular to run this via crontab, which is fine. But the behavior of the script has been somewhat, shall we say, annoying.
+If you want to use plexupdate as either a cron job or as a [systemd job](https://github.com/mrworf/plexupdate/wiki/Running-plexupdate-daily-as-a-systemd-timer), the -c option should do what you want. All non-error exit codes will be set to 0 and no output will be printed to stdout unless something has actually been done. (a new version was downloaded, installed, etc)
 
-Starting today, the ```-C``` option is deprecated and will give an error to check the docs. The new version is ```-c``` and will make sure that only fatal errors are reported back via the exit code. No more 2, 3, 4 or 5 exitcodes. They are converted into 0. Combining this option with ```-q``` will hide any and all non-essential output from the script as well. Only error messages are emitted, so if it fails, you'll know why.
-
-Take a look at the Wiki, and find the article called [Running plexupdate daily as a systemd timer](https://github.com/mrworf/plexupdate/wiki/Running-plexupdate-daily-as-a-systemd-timer).
-
-## 4. Command-line
-
-I'm going to be lazy, just run the tool with `-h` and you'll find out what you can do. It will basically be a mirror of what section 3 just stated :-)
+If you don't even want to know when something has been done, you can combine this with the -q option and you will only receive output in the event of an error. Everything else will just silenty finish without producing any output.
 
 # Running it
 
@@ -112,6 +106,6 @@ The username and password for http://plex.tv
 
 ## My password is rejected even though correct
 
-If you use certain characters, such as dollar sign, in your password, bash will interpret that as a reference to a variable. To resolve this, enclose your password with single quotes instead of the normal quotes.
+If you use certain characters (such as `$`) in your password, bash will interpret that as a reference to a variable. To resolve this, enclose your password within single quotes (`'`) instead of the normal quotes (`"`).
 
-Ie, `PASS="MyP4$$w0rD"` will not work, but changing to it to `PASS='MyP4$$w0rD'` will
+i.e. `PASS="MyP4$$w0rD"` will not work, but changing to it to `PASS='MyP4$$w0rD'` will

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -125,7 +125,7 @@ URL_DOWNLOAD_PUBLIC=https://plex.tv/api/downloads/1.json
 
 cronexit() {
 	# Don't give anything but true error codes if in CRON mode
-	rawexit=$1
+	RAWEXIT=$1
 	if [ "${CRON}" = "yes" -a $1 -gt 1 -a $1 -lt 255 ]; then
 		exit 0
 	fi
@@ -206,8 +206,8 @@ fi
 
 if [ "${CRON}" = "yes" -a "${QUIET}" = "no" ]; then
 	# If running in cron mode, redirect STDOUT to temporary file
-	stdoutlog="$(mktemp)"
-	exec 3>&1 >"${stdoutlog}"
+	STDOUTLOG="$(mktemp)"
+	exec 3>&1 >"${STDOUTLOG}"
 elif [ "${QUIET}" = "yes" ]; then
 	# Redirect STDOUT to dev null. Use >&3 if you really, really, REALLY need to print to STDOUT
 	exec 3>&1 > /dev/null
@@ -331,11 +331,11 @@ keypair() {
 
 # Setup an cronexit handler so we cleanup
 function cleanup {
-	if [ "${CRON}" = yes -a "${rawexit}" -ne 5 -a -f "${stdoutlog}" ]; then
+	if [ "${CRON}" = yes -a "${RAWEXIT}" -ne 5 -a -f "${STDOUTLOG}" ]; then
 		exec 1>&3
-		cat "${stdoutlog}"
+		cat "${STDOUTLOG}"
 	fi
-	rm "${stdoutlog}" 2>/dev/null >/dev/null
+	rm "${STDOUTLOG}" 2>/dev/null >/dev/null
 	rm /tmp/postdata 2>/dev/null >/dev/null
 	rm /tmp/raw 2>/dev/null >/dev/null
 	rm /tmp/failcause 2>/dev/null >/dev/null

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -31,7 +31,7 @@
 ####################################################################
 # Quick-check before we allow bad things to happen
 if [ -z "${BASH_VERSINFO}" ]; then
-  echo "ERROR: You must execute this script with BASH"
+  echo "ERROR: You must execute this script with BASH" >&2
   exit 255
 fi
 ####################################################################
@@ -141,7 +141,7 @@ usage() {
 	echo "    -c Cron mode, only fatal errors return non-zero cronexit code"
         echo "    -d Auto delete after auto install"
         echo "    -f Force download even if it's the same version or file"
-        echo "       already exists (WILL NOT OVERWRITE)"
+        echo "       already exists"
         echo "    -h This help"
         echo "    -l List available builds and distros"
         echo "    -p Public Plex Media Server version"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -66,9 +66,8 @@ DEBIAN_INSTALL="dpkg -i"
 DISTRO_INSTALL=""
 
 # Sanity, make sure wget is in our path...
-wget >/dev/null 2>/dev/null
-if [ $? -eq 127 ]; then
-	echo "Error: This script requires wget in the path. It could also signify that you don't have the tool installed." >&2
+if hash wget 2>/dev/null; then
+	echo "ERROR: This script requires wget in the path. It could also signify that you don't have the tool installed." >&2
 	exit 1
 fi
 
@@ -209,9 +208,8 @@ if [ "${QUIET}" = "yes" ]; then
 fi
 
 if [ "${AUTOUPDATE}" == "yes" ]; then
-	git >/dev/null 2>/dev/null
-	if [ $? -eq 127 ]; then
-		echo "Error: You need to have git installed for this to work" >&2
+	if hash git 2>/dev/null; then
+		echo "ERROR: You need to have git installed for this to work" >&2
 		cronexit 1
 	fi
 	pushd "$(dirname "$0")" >/dev/null

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -66,7 +66,7 @@ DEBIAN_INSTALL="dpkg -i"
 DISTRO_INSTALL=""
 
 # Sanity, make sure wget is in our path...
-if hash wget 2>/dev/null; then
+if ! hash wget 2>/dev/null; then
 	echo "ERROR: This script requires wget in the path. It could also signify that you don't have the tool installed." >&2
 	exit 1
 fi
@@ -204,7 +204,7 @@ if [ ! -z "${RELEASE}" ]; then
 fi
 
 if [ "${AUTOUPDATE}" = "yes" ]; then
-	if hash git 2>/dev/null; then
+	if ! hash git 2>/dev/null; then
 		echo "ERROR: You need to have git installed for this to work" >&2
 		cronexit 1
 	fi
@@ -500,7 +500,7 @@ if [ "${AUTOSTART}" = "yes" ]; then
 		echo "The AUTOSTART [-s] option may not be needed on your distribution."
 	fi
 	# Check for systemd
-	if [ -f "/bin/systemctl" ]; then
+	if ! hash systemctl 2>/dev/null; then
 		systemctl start plexmediaserver.service
 	else
 		/sbin/service plexmediaserver start

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -118,12 +118,6 @@ else
 	fi
 fi
 
-if [ ! "${RELEASE}" = "" ]; then
-	echo "ERROR: RELEASE keyword is deprecated and should be removed from .plexupdate" >&2
-	echo "       Use DISTRO and BUILD instead to manually select what to install (check README.md)" >&2
-	exit 255
-fi
-
 # Current pages we need - Do not change unless Plex.tv changes again
 URL_LOGIN=https://plex.tv/users/sign_in.json
 URL_DOWNLOAD=https://plex.tv/api/downloads/1.json?channel=plexpass
@@ -174,7 +168,7 @@ do
                 (-h) usage;;
                 (-a) AUTOINSTALL=yes;;
                 (-c) CRON=yes;;
-		(-C) echo "ERROR: CRON option has changed, please review README.md" 1>&2; cronexit 255;;
+		(-C) echo "ERROR: CRON option has changed, please review README.md" >&2; cronexit 255;;
                 (-d) AUTODELETE=yes;;
                 (-f) FORCE=yes;;
                 (-l) LISTOPTS=yes;;
@@ -182,29 +176,31 @@ do
                 (-q) QUIET=yes;;
                 (-r) PRINT_URL=yes;;
                 (-s) AUTOSTART=yes;;
-		(-S) echo "ERROR: SILENT option has been removed, please use QUIET (-q) instead" 1>&2; cronexit 1;;
+		(-S) echo "ERROR: SILENT option has been removed, please use QUIET (-q) instead" >&2; cronexit 255;;
                 (-u) AUTOUPDATE=yes;;
                 (-U) AUTOUPDATE=no;;
                 (--) ;;
-                (-*) echo "Error: unrecognized option $1" 1>&2; usage; cronexit 1;;
+                (-*) echo "ERROR: unrecognized option $1" >&2; usage; cronexit 1;;
                 (*)  break;;
 	esac
 	shift
 done
 
 if [ "${KEEP}" = "yes" ]; then
-	echo "ERROR: KEEP is deprecated" >&2
-	cronexit 1
+	echo "ERROR: KEEP is deprecated and should be removed from .plexupdate" >&2
+	cronexit 255
 fi
 
 if [ "${SILENT}" = "yes" ]; then
-	echo "ERROR: SILENT option has been removed, please use QUIET instead" >&2
-	cronexit 1
+	echo "ERROR: SILENT option has been removed and should be removed from .plexupdate" >&2
+	echo "       Use QUIET or -q instead" >&2
+	cronexit 255
 fi
 
-# send all stdout to /dev/null
-if [ "${QUIET}" = "yes" ]; then
-	exec 5>&1 >/dev/null
+if [ ! -z "${RELEASE}" ]; then
+	echo "ERROR: RELEASE keyword is deprecated and should be removed from .plexupdate" >&2
+	echo "       Use DISTRO and BUILD instead to manually select what to install (check README.md)" >&2
+	cronexit 255
 fi
 
 if [ "${AUTOUPDATE}" == "yes" ]; then
@@ -214,18 +210,18 @@ if [ "${AUTOUPDATE}" == "yes" ]; then
 	fi
 	pushd "$(dirname "$0")" >/dev/null
 	if [ ! -d .git ]; then
-		echo "Error: This is not a git repository, auto update only works if you've done a git clone" >&2
+		echo "ERROR: This is not a git repository, auto update only works if you've done a git clone" >&2
 		cronexit 1
 	fi
 	git status | grep "git commit -a" >/dev/null 2>/dev/null
 	if [ $? -eq 0 ]; then
-		echo "Error: You have made changes to the script, cannot auto update" >&2
+		echo "ERROR: You have made changes to the script, cannot auto update" >&2
 		cronexit 1
 	fi
 	echo -n "Auto updating..."
 	git pull >/dev/null
 	if [ $? -ne 0 ]; then
-		echo 'Error: Unable to update git, try running "git pull" manually to see what is wrong' >&2
+		echo 'ERROR: Unable to update git, try running "git pull" manually to see what is wrong' >&2
 		cronexit 1
 	fi
 	echo "OK"
@@ -243,7 +239,7 @@ if [ "${AUTOUPDATE}" == "yes" ]; then
 		if [ -f "$0" ]; then
 			/bin/bash "$0" -U ${ALLARGS[@]}
 		else
-			echo "Error: Unable to relaunch, couldn't find $0" >&2
+			echo "ERROR: Unable to relaunch, couldn't find $0" >&2
 			cronexit 1
 		fi
 	else
@@ -254,14 +250,14 @@ fi
 
 # Sanity check
 if [ "${EMAIL}" == "" -o "${PASS}" == "" ] && [ "${PUBLIC}" == "no" ] && [ ! -f /tmp/kaka ]; then
-	echo "Error: Need username & password to download PlexPass version. Otherwise run with -p to download public version." >&2
+	echo "ERROR: Need username & password to download PlexPass version. Otherwise run with -p to download public version." >&2
 	cronexit 1
 fi
 
 if [ "${AUTOINSTALL}" == "yes" -o "${AUTOSTART}" == "yes" ]; then
 	id | grep -i 'uid=0(' 2>&1 >/dev/null
 	if [ $? -ne 0 ]; then
-		echo "Error: You need to be root to use autoinstall/autostart option." >&2
+		echo "ERROR: You need to be root to use autoinstall/autostart option." >&2
 		cronexit 1
 	fi
 fi
@@ -270,7 +266,7 @@ fi
 # Remove any ~ or other oddness in the path we're given
 DOWNLOADDIR="$(eval cd ${DOWNLOADDIR// /\\ } ; if [ $? -eq 0 ]; then pwd; fi)"
 if [ -z "${DOWNLOADDIR}" ]; then
-	echo "Error: Download directory does not exist or is not a directory" >&2
+	echo "ERROR: Download directory does not exist or is not a directory" >&2
 	cronexit 1
 fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -275,7 +275,7 @@ fi
 
 # Remove any ~ or other oddness in the path we're given
 DOWNLOADDIR="$(cd ${DOWNLOADDIR// /\\ } && pwd)"
-if [ -z "${DOWNLOADDIR}" ]; then
+if [ ! -d "${DOWNLOADDIR}" ]; then
 	echo "ERROR: Download directory does not exist or is not a directory" >&2
 	cronexit 1
 fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -519,10 +519,15 @@ if [ "${AUTOSTART}" = "yes" ]; then
 		echo "The AUTOSTART [-s] option may not be needed on your distribution." >&2
 	fi
 	# Check for systemd
-	if ! hash systemctl 2>/dev/null; then
+	if hash systemctl 2>/dev/null; then
 		systemctl start plexmediaserver.service
+	elif hash service 2>/dev/null; then
+		service plexmediaserver start
+	elif [ -x /etc/init.d/plexmediaserver ]; then
+		/etc/init.d/plexmediaserver start
 	else
-		/sbin/service plexmediaserver start
+		echo "ERROR: AUTOSTART was specified but no startup scripts were found for 'plexmediaserver'." >&2
+		cronexit 1
 	fi
 fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -516,7 +516,7 @@ fi
 
 if [ "${AUTOSTART}" = "yes" ]; then
 	if [ "${REDHAT}" = "no" ]; then
-		echo "The AUTOSTART [-s] option may not be needed on your distribution."
+		echo "The AUTOSTART [-s] option may not be needed on your distribution." >&2
 	fi
 	# Check for systemd
 	if ! hash systemctl 2>/dev/null; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -264,7 +264,7 @@ fi
 
 
 # Remove any ~ or other oddness in the path we're given
-DOWNLOADDIR="$(eval cd ${DOWNLOADDIR// /\\ } ; if [ $? -eq 0 ]; then pwd; fi)"
+DOWNLOADDIR="$(cd ${DOWNLOADDIR// /\\ } && pwd)"
 if [ -z "${DOWNLOADDIR}" ]; then
 	echo "ERROR: Download directory does not exist or is not a directory" >&2
 	cronexit 1

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -274,7 +274,7 @@ fi
 
 
 # Remove any ~ or other oddness in the path we're given
-DOWNLOADDIR="$(cd ${DOWNLOADDIR// /\\ } && pwd)"
+DOWNLOADDIR="$(eval cd ${DOWNLOADDIR// /\\ } && pwd)"
 if [ ! -d "${DOWNLOADDIR}" ]; then
 	echo "ERROR: Download directory does not exist or is not a directory" >&2
 	cronexit 1


### PR DESCRIPTION
This changes the behavior of the -c option to make it useful for cron users with or without the -q option. Without -q, output will only be generated if something is actually done. With -q, output will only be generated in the event of an error. In both cases, exit codes will be "normalized" so that systemd doesn't get false alarms.

There are also a handful of other commits here for random code cleanup that I did as part of this work. I intentionally didn't squash these so that if anyone has a problem with some of the changes we can easily do a git revert.

Closes #84 