### PR TITLE
Fix PATH on Ubuntu systems if dpkg is likely to fail during AUTOINSTALL

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -548,7 +548,7 @@ if [ ! -z "${PLEXSERVER}" -a "${AUTOINSTALL}" = "yes" ]; then
 fi
 
 if [ "${AUTOINSTALL}" = "yes" ]; then
-	if ! hash ldconfig 2>/dev/null && [ -a "${DISTRO}" = "ubuntu" ]; then
+	if ! hash ldconfig 2>/dev/null && [ "${DISTRO}" = "ubuntu" ]; then
 		export PATH=$PATH:/sbin
 	fi
 	# no elif since DISTRO_INSTALL will produce error output for us

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -548,6 +548,11 @@ if [ ! -z "${PLEXSERVER}" -a "${AUTOINSTALL}" = "yes" ]; then
 fi
 
 if [ "${AUTOINSTALL}" = "yes" ]; then
+	if ! hash ldconfig 2>/dev/null && [ -x /sbin/ldconfig -a "${DISTRO}" = "ubuntu" ]; then
+		export PATH=$PATH:/sbin
+	fi
+	# no elif since DISTRO_INSTALL will produce error output for us
+
 	${DISTRO_INSTALL} "${DOWNLOADDIR}/${FILENAME}"
 fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -548,7 +548,7 @@ if [ ! -z "${PLEXSERVER}" -a "${AUTOINSTALL}" = "yes" ]; then
 fi
 
 if [ "${AUTOINSTALL}" = "yes" ]; then
-	if ! hash ldconfig 2>/dev/null && [ -x /sbin/ldconfig -a "${DISTRO}" = "ubuntu" ]; then
+	if ! hash ldconfig 2>/dev/null && [ -a "${DISTRO}" = "ubuntu" ]; then
 		export PATH=$PATH:/sbin
 	fi
 	# no elif since DISTRO_INSTALL will produce error output for us


### PR DESCRIPTION
Intentionally kept this simple. If ldconfig can't be found and we're running on ubuntu, just add /sbin to the PATH and continue on as normal. Any error output will still be generated by dpkg once it runs, but this should prevent that in most cases.

Fixes #97