### PR TITLE
Argument changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,43 +17,39 @@ Download it as a [zip file](https://github.com/mrworf/plexupdate/archive/master.
 ```
 wget https://github.com/mrworf/plexupdate/archive/master.zip && unzip master.zip && mv plexupdate-master plexupdate && rm master.zip
 ```
-Note that unzip is requered (`sudo apt-get install unzip`).
+Note that unzip is required (`sudo apt-get install unzip`).
 
 ####Using git to clone (Recommended)
 Using git is way easier and recommended, if you ask me. 
 ```
 git clone https://github.com/mrworf/plexupdate.git
 ```
-Note that git is requered (`sudo apt-get install git-all`)
+Note that git is required (`sudo apt-get install git-all`)
 
 The main benefit with git clone is that you can update to latest version very easily. If you want to use the auto update feature, you must be using a git clone.
 
 ## 2. Setting it up
 
-plexupdate.sh looks for a file named `.plexupdate` located in your home directory. Please note that I'm referring to the home directory of the user who is running the plexupdate.sh ... If that user is someone else (root for instance) you'll need to make sure that user has the config file set up properly as well.
-
-The contents of this file are usually:
+To quickly setup plexupdate.sh, you should run it the first time like below:
 
 ```
-EMAIL="my.email@plex-server.com"
-PASS="my-secret-plex-password"
-DOWNLOADDIR="/a/folder/to/save/the/files/in"
+./plexupdate.sh --email="my.email@plex-server.com" --pass="my-secret-plex-password" --dldir="/a/folder/to/save/the/files/in" --saveconfig
 ```
 
-Obviously you need to change these so they match your account information. And if you don't put anything as a `DOWNLOADDIR`, the tool will use the folder you're executing the script from. So take care.
+Obviously you need to change these so they match your account information. And if you don't put anything as for the ```--dldir``` option, the tool will use the folder you're executing the script from. So take care.
 
 ## 3. Advanced options
 
-You can point out a different file than ```.plexupdate``` by providing it as the last argument to the script. It HAS to be the LAST argument, or it will be ignored. Any options set by the config file can be overriden with command-line options.
+You can point out a different file than ```.plexupdate``` by providing it as the argument to the ```--config``` option. Any options set by the config file can be overridden with command-line options.
 
 There are also a few additional options for the more enterprising user. Setting any of these to `yes` will enable the function.
 
 - PLEXSERVER
-  If set, and combined with AUTOINSTALL, the script will automatically check if the server is in-use and deferr the update. Great for crontab users. PLEXSERVER should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
+  If set, and combined with AUTOINSTALL, the script will automatically check if the server is in-use and defer the update. Great for crontab users. PLEXSERVER should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
 - AUTOUPDATE
   Makes plexupdate.sh automatically update itself using git. Note! This will fail if git isn't available on the command line.
 - AUTOINSTALL
-  Automatically installs the newly downloaded version. Currently works for debian based systems as well as rpm based distros. Will fail miserably if you're not root.
+  Automatically installs the newly downloaded version. Currently works for Debian based systems as well as rpm based distros. Will fail miserably if you're not root.
 - AUTODELETE 
   Once successfully downloaded and installed, it will delete the package (want not, waste not? ;-))
 - PUBLIC 
@@ -76,7 +72,24 @@ Most of these options can be specified on the command-line as well, this is just
 
 If you want to use plexupdate as either a cron job or as a [systemd job](https://github.com/mrworf/plexupdate/wiki/Running-plexupdate-daily-as-a-systemd-timer), the -c option should do what you want. All non-error exit codes will be set to 0 and no output will be printed to stdout unless something has actually been done. (a new version was downloaded, installed, etc)
 
-If you don't even want to know when something has been done, you can combine this with the -q option and you will only receive output in the event of an error. Everything else will just silenty finish without producing any output.
+If you don't even want to know when something has been done, you can combine this with the -q option and you will only receive output in the event of an error. Everything else will just silently finish without producing any output.
+
+### Command Line Options
+
+Several new command line options are available. They can be specified in any order.
+
+- ```--config <path/to/config/file>```
+  Defines the location the script should look for the config file. 
+- ```--email <Plex.tv email>```
+  Email to sign in to Plex.tv
+- ```--pass <Plex.tv password>```
+  Password to sign in to Plex.tv
+- ```--dldir <path/to/where/you/want/files/downloaded/to>```
+  This is the folder that the files will be downloaded to.
+- ```--server <Plex server address>```
+  This is the address that Plex Media Server is on. Setting this will enable a check to see if users are on the server prior to the software being updated.
+- ```--saveconfig```
+  Saves the configuration as it is currently. This will take whatever is in the config file, plus whatever is specified on the command line and will save the config file with that information. Any information in the config file that plexupdate.sh does not understand or use WILL BE LOST. 
 
 # Running it
 
@@ -86,7 +99,7 @@ Overall it tries to give you hints regarding why it isn't doing what you expecte
 
 # Trivia
 
-- "kaka" is swedish for "cookie"
+- "kaka" is Swedish for "cookie"
 
 # TL;DR
 Open a terminal or SSH on the server running Plex Media Center

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -84,7 +84,7 @@ cronexit() {
 }
 
 usage() {
-	echo "Usage: $(basename $0) [-acdfFhlpqsuU]"
+	echo "Usage: $(basename $0) [-acdfFhlpqsuU] [<long options>]"
 	echo ""
 	echo ""
 	echo "    -a Auto install if download was successful (requires root)"
@@ -108,7 +108,7 @@ usage() {
 	echo "    --email <plex.tv email> Plex.TV email address"
 	echo "    --pass <plex.tv password> Plex.TV password"
 	echo "    --server <Plex server address> Address of Plex Server"
-	echo "    --saveconfig Save the command line arguments to "
+	echo "    --saveconfig Save the configuration to config file"
 	echo
 	cronexit 0
 }

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -138,6 +138,18 @@ running() {
 	fi
 }
 
+trimQuotes() {
+  local __retvar=$1
+  local __buffer=${!__retvar}
+
+  # Remove leading single quote
+  __buffer=${__buffer#\'}
+  # Remove ending single quote
+  __buffer=${__buffer%\'}
+
+  echo $__buffer
+}
+
 # Parse commandline
 ALLARGS=( "$@" )
 optstring="acCdfFhlpqrSsuU -l config:,dldir:,email:,pass:,server:,saveconfig"
@@ -170,11 +182,11 @@ do
 		(-u) AUTOUPDATE_CL=yes;;
 		(-U) IGNOREAUTOUPDATE=yes;;
 
-		(--config) shift; CONFIGFILE=$(echo "$1" | tr -d "'");;
-		(--dldir) shift; DOWNLOADDIR_CL=$(echo "$1" | tr -d "'");;
-		(--email) shift; EMAIL_CL=$(echo "$1" | tr -d "'");;
-		(--pass) shift; PASS_CL=$(echo "$1" | tr -d "'");;
-		(--server) shift; PLEXSERVER_CL=$(echo "$1" | tr -d "'");;
+    (--config) shift; CONFIGFILE="$1"; CONFIGFILE=$(trimQuotes CONFIGFILE);;
+    (--dldir) shift; DOWNLOADDIR_CL="$1"; DOWNLOADDIR_CL=$(trimQuotes DOWNLOADDIR_CL);; 
+    (--email) shift; EMAIL_CL="$1"; EMAIL_CL=$(trimQuotes EMAIL_CL);;
+    (--pass) shift; PASS_CL="$1"; PASS_CL=$(trimQuotes PASS_CL);;
+    (--server) shift; PLEXSERVER_CL="$1"; PLEXSERVER_CL=$(trimQuotes PLEXSERVER_CL);;
 		(--saveconfig) SAVECONFIG=yes;;
 
 		(--) ;;

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -139,8 +139,7 @@ running() {
 }
 
 trimQuotes() {
-  local __retvar=$1
-  local __buffer=${!__retvar}
+    local __buffer=$1
 
   # Remove leading single quote
   __buffer=${__buffer#\'}
@@ -182,11 +181,11 @@ do
 		(-u) AUTOUPDATE_CL=yes;;
 		(-U) IGNOREAUTOUPDATE=yes;;
 
-    (--config) shift; CONFIGFILE="$1"; CONFIGFILE=$(trimQuotes CONFIGFILE);;
-    (--dldir) shift; DOWNLOADDIR_CL="$1"; DOWNLOADDIR_CL=$(trimQuotes DOWNLOADDIR_CL);; 
-    (--email) shift; EMAIL_CL="$1"; EMAIL_CL=$(trimQuotes EMAIL_CL);;
-    (--pass) shift; PASS_CL="$1"; PASS_CL=$(trimQuotes PASS_CL);;
-    (--server) shift; PLEXSERVER_CL="$1"; PLEXSERVER_CL=$(trimQuotes PLEXSERVER_CL);;
+    (--config) shift; CONFIGFILE="$1"; CONFIGFILE=$(trimQuotes ${CONFIGFILE});;
+    (--dldir) shift; DOWNLOADDIR_CL="$1"; DOWNLOADDIR_CL=$(trimQuotes ${DOWNLOADDIR_CL});; 
+    (--email) shift; EMAIL_CL="$1"; EMAIL_CL=$(trimQuotes ${EMAIL_CL});;
+    (--pass) shift; PASS_CL="$1"; PASS_CL=$(trimQuotes ${PASS_CL});;
+    (--server) shift; PLEXSERVER_CL="$1"; PLEXSERVER_CL=$(trimQuotes ${PLEXSERVER_CL});;
 		(--saveconfig) SAVECONFIG=yes;;
 
 		(--) ;;

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -149,6 +149,14 @@ trimQuotes() {
   echo $__buffer
 }
 
+HASCFG="${@: -1}"
+if [ ! -z "${HASCFG}" -a ! "${HASCFG:0:1}" = "-" ]; then
+	if [ -f "${HASCFG}" ]; then
+		echo "WARNING: Specifying config file as last argument is deprecated. Use --config <path> instead."
+		CONFIGFILE=${HASCFG}
+	fi
+fi
+
 # Parse commandline
 ALLARGS=( "$@" )
 optstring="acCdfFhlpqrSsuU -l config:,dldir:,email:,pass:,server:,saveconfig"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -31,8 +31,8 @@
 ####################################################################
 # Quick-check before we allow bad things to happen
 if [ -z "${BASH_VERSINFO}" ]; then
-  echo "ERROR: You must execute this script with BASH" >&2
-  exit 255
+	echo "ERROR: You must execute this script with BASH" >&2
+	exit 255
 fi
 ####################################################################
 # Set these three settings to what you need, or create a .plexupdate file
@@ -384,7 +384,7 @@ if [ -f /tmp/kaka_token ]; then
 fi
 
 if [ "${PUBLIC}" = "no" ]; then
-        echo -n "Authenticating..."
+	echo -n "Authenticating..."
 
 	# Clean old session
 	rm /tmp/kaka 2>/dev/null
@@ -417,7 +417,8 @@ if [ "${PUBLIC}" = "no" ]; then
 	# Remove this, since it contains more information than we should leave hanging around
 	rm /tmp/failcause
 
-        echo "OK"
+	echo "OK"
+
 elif [ "$PUBLIC" != "no" ]; then
 	# It's a public version, so change URL and make doubly sure that cookies are empty
 	rm 2>/dev/null >/dev/null /tmp/kaka
@@ -451,7 +452,7 @@ if [ "${LISTOPTS}" = "yes" ]; then
 fi
 
 # Extract the URL for our release
-        echo -n "Finding download URL to download..."
+echo -n "Finding download URL to download..."
 
 # Set "X-Plex-Token" to the auth token, if no token is specified or it is invalid, the list will return public downloads by default
 RELEASE=$(wget --header "X-Plex-Token:"${TOKEN}"" --load-cookies /tmp/kaka --save-cookies /tmp/kaka --keep-session-cookies "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -ioe '"label"[^}]*' | grep -i "\"distro\":\"${DISTRO}\"" | grep -m1 -i "\"build\":\"${BUILD}\"")
@@ -473,12 +474,12 @@ fi
 echo "${CHECKSUM}  ${DOWNLOADDIR}/${FILENAME}" >"${DOWNLOADDIR}/${FILENAME}.sha"
 
 if [ "${PRINT_URL}" = "yes" ]; then
-  if [ "${QUIET}" = "yes" ]; then
-    echo "${DOWNLOAD}" >&3
-  else
-    echo "${DOWNLOAD}"
-  fi
-  cronexit 0
+	if [ "${QUIET}" = "yes" ]; then
+		echo "${DOWNLOAD}" >&3
+	else
+		echo "${DOWNLOAD}"
+	fi
+	cronexit 0
 fi
 
 # By default, try downloading
@@ -495,8 +496,8 @@ else
 fi
 
 if [[ $FILENAME == *$INSTALLED_VERSION* ]] && [ "${FORCE}" != "yes" -a "${FORCEALL}" != "yes" ] && [ ! -z "${INSTALLED_VERSION}" ]; then
-        echo "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
-        cronexit 5
+	echo "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
+	cronexit 5
 fi
 
 if [ -f "${DOWNLOADDIR}/${FILENAME}" ]; then


### PR DESCRIPTION
Okay, feel free to pull this in if you choose. Basically, what this patch does is makes a few changes to the command line parsing. It makes it so that rather than the config file being the last item in the list of arguments, it is now following a long option parameter (--config). There are some other long options that enable the user to define everything from the command line. There is also an option that will allow you to save your settings as they stand to the configuration file. 

I also fixed some issues with tabs that had been converted to spaces, as well as fixed some spelling mistakes in README.md.

Let me know if this is okay, or if you want me to make any changes before it get's pulled in. 