### PR TITLE
Remove checksum output to file

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -470,8 +470,6 @@ if [ $? -ne 0 ]; then
 	cronexit 3
 fi
 
-echo "${CHECKSUM}  ${DOWNLOADDIR}/${FILENAME}" >"${DOWNLOADDIR}/${FILENAME}.sha"
-
 if [ "${PRINT_URL}" = "yes" ]; then
   if [ "${QUIET}" = "yes" ]; then
     echo "${DOWNLOAD}" >&3


### PR DESCRIPTION
In the changes committed in 858a429, the checksum is output to a file in the download directory which is not later cleaned up.  The script shouldn't output files that aren't later cleaned up as it ends up just polluting the directory in which plexupdate is run.