### PR TITLE
Fix for no arguments causing error.

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -156,11 +156,13 @@ trimQuotes() {
   echo $__buffer
 }
 
-HASCFG="${@: -1}"
-if [ ! -z "${HASCFG}" -a ! "${HASCFG:0:1}" = "-" -a ! "${@:(-2):1}" = "--config" ]; then
-	if [ -f "${HASCFG}" ]; then
-		echo "WARNING: Specifying config file as last argument is deprecated. Use --config <path> instead."
-		CONFIGFILE=${HASCFG}
+if [ ! $# -eq 0 ]; then
+	HASCFG="${@: -1}"
+	if [ ! -z "${HASCFG}" -a ! "${HASCFG:0:1}" = "-" -a ! "${@:(-2):1}" = "--config" ]; then
+		if [ -f "${HASCFG}" ]; then
+			echo "WARNING: Specifying config file as last argument is deprecated. Use --config <path> instead."
+			CONFIGFILE=${HASCFG}
+		fi
 	fi
 fi
 


### PR DESCRIPTION
The recent fix for the deprecation error caused another issue #118. This fixes it by checking if we have any arguments before checking for a config file. I've checked this as follows:

`plexupdate.sh` -> Runs normally
`plexupdate.sh --config ~/.plexupdate` -> Runs normally
`plexupdate.sh ~/.plexupdate` -> Gives deprecation warning and runs normally