### PR TITLE
Add missing quotes

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -351,7 +351,7 @@ for VAR in AUTOINSTALL CRON AUTODELETE DOWNLOADDIR EMAIL PASS FORCE FORCEALL PUB
 do
 	VAR2="$VAR""_CL"
 	if [ ! -z ${!VAR2} ]; then
-		eval $VAR=${!VAR2}
+		eval $VAR='${!VAR2}'
 	fi
 done
 


### PR DESCRIPTION
Closes #126 . There was an issue with a missing set of quotes before an eval that caused the eval to perform bash substitution when it was not desired.