### PR TITLE
More missing quotes

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -396,10 +396,14 @@ if [ "${SAVECONFIG}" = "yes" ]; then
 			-o ${VAR} = "QUIET" ]; then
 
 				if [ ${!VAR} = "yes" ]; then
-					echo "${VAR}=${!VAR}" >> ${CONFIGFILE}
+					echo "${VAR}='${!VAR}'" >> ${CONFIGFILE}
+				fi
+			elif [ ${VAR} = "PLEXPORT" ]; then
+				if [ ! "${!VAR}" = "32400" ]; then
+					echo "${VAR}='${!VAR}'" >> ${CONFIGFILE}
 				fi
 			else
-				echo "${VAR}=${!VAR}" >> ${CONFIGFILE}
+				echo "${VAR}='${!VAR}'" >> ${CONFIGFILE}
 			fi
 		fi
 	done


### PR DESCRIPTION
When #127 was done, missed quotes that were necessary in the saveconfig section. Without the quotes added, bash substitution occurs and mangles the passwords. This is not occurring when the script is run with saveconfig, but rather when the script gets run the next time without command line options. This should permanently close #130 and fix the issue with the passwords.