### PR TITLE
Fixes for cronwrapper behavior

### DIFF
--- a/extras/cronwrapper
+++ b/extras/cronwrapper
@@ -39,7 +39,7 @@ if [ ! -z "$CONF" ]; then
     echo "ERROR: Cannot find config file (tried ${CONF})" >&2
     exit 255
   fi
-  CONF="--config \"${CONF}\""
+  CONF="--config=${CONF}"
 fi
 
 LOGFILE=$(mktemp /tmp/plexupdate.cron.XXXX)

--- a/extras/cronwrapper
+++ b/extras/cronwrapper
@@ -51,7 +51,7 @@ if $LOGGING; then
     RET=1
   fi
 else
-  "${SCRIPT}" "${CONF}" 2>&1 >${LOGFILE}
+  "${SCRIPT}" "${CONF}" >${LOGFILE} 2>&1
   RET=$?
 fi
 

--- a/extras/cronwrapper
+++ b/extras/cronwrapper
@@ -55,7 +55,7 @@ else
   RET=$?
 fi
 
-if [ $RET -ne 0 -a $RET -ne 2 -a $RET -ne 5 ]; then
+if [ $RET -ne 2 -a $RET -ne 5 ]; then
   # Make sure user gets an email about this
   cat ${LOGFILE} >&2
 else

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -192,7 +192,7 @@ keypair() {
 
 # Setup an exit handler so we cleanup
 cleanup() {
-	for F in "${FILE_RAW}" "${FILE_FAILCAUSE}" "${FILE_POSTDATA}" "${FILE_KAKA}" "${FILE_SHA}" "${FILE_LOCAL}" "${FILE_REMOTE}"; do
+	for F in "${FILE_RAW}" "${FILE_FAILCAUSE}" "${FILE_POSTDATA}" "${FILE_KAKA}" "${FILE_SHA}" "${FILE_LOCAL}" "${FILE_REMOTE}" "${FILE_WGETLOG}"; do
 		rm "$F" 2>/dev/null >/dev/null
 	done
 }


### PR DESCRIPTION
A few fixes for cronwrapper behavior. With these, cronwrapper matches the old -c behavior almost perfectly. We can add some notes to the wiki for folks that want to customize it further. (i.e. if you only want cron to notify you on actual errors, and not just if a new version is actually installed)

Note that while fixing the issue with CONF causing cronwrapper to error out, I discovered that plexupdate itself can't handle config files with spaces in the name. That's a separate fix that I'll try tackling later (unless someone would like to volunteer in the meantime) since it's not "newly broken".