### PR TITLE
Deprecated exit code 5 and corrcted cronwrapper and enhanced README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ But here are some of the more useful ones:
 
 See explanation in the top of this document.
 
+## I saw it, but I miss `.plexupdate`
+
+If you desparately want the old behavior, please add the following to `/etc/plexupdate.conf` :
+
+```
+if [ -f ~/.plexupdate ]
+  source ~/.plexupdate
+fi
+```
+
+This will make `plexupdate.sh` look in current user's home directory for configuration file. But this should be considered a stop-gap solution and is not officially endorsed.
+
+## Do I have to use the `extras/installer.sh` ?
+
+Of course not, anything you find under `extras/` is optional and only provided as a easier way to get `plexupdate.sh` up and running quickly.
+
 ## What email and password are you talking about
 
 The email and password for http://plex.tv

--- a/README.md
+++ b/README.md
@@ -161,18 +161,6 @@ But here are some of the more useful ones:
 
 See explanation in the top of this document.
 
-## I saw it, but I miss `.plexupdate`
-
-If you desparately want the old behavior, please add the following to `/etc/plexupdate.conf` :
-
-```
-if [ -f ~/.plexupdate ]
-  source ~/.plexupdate
-fi
-```
-
-This will make `plexupdate.sh` look in current user's home directory for configuration file. But this should be considered a stop-gap solution and is not officially endorsed.
-
 ## Do I have to use the `extras/installer.sh` ?
 
 Of course not, anything you find under `extras/` is optional and only provided as a easier way to get `plexupdate.sh` up and running quickly.
@@ -188,3 +176,7 @@ If you use certain characters (such as `$`) in your password, bash will interpre
 i.e. `PASS="MyP4$$w0rD"` will not work, but changing to it to `PASS='MyP4$$w0rD'` will
 
 If it's still not working, run `plexupdate.sh` with `-v` which prints out the email and password used to login which might help you understand what the problem is.
+
+# Not finding what you're looking for?
+
+See https://github.com/mrworf/plexupdate/wiki for more information

--- a/extras/cronwrapper
+++ b/extras/cronwrapper
@@ -14,10 +14,10 @@
 # LOGGING if true, logs all output to syslog daemon facility
 #         (typically /var/log/daemon.log or /var/log/syslog)
 #
-# Set CONFIGURED to true once you've setup the previous three
-# options.
+# NOTIFYONRETURN is used to define which return codes from plexupdate
+#                that you want to be notified for. By default, all
+#                non-zero return codes produce a notification.
 #
-
 
 if [ ! -f /etc/plexupdate.cron.conf ]; then
 	echo "ERROR: You have not configured /etc/plexupdate.cron.conf" >&2
@@ -59,8 +59,8 @@ else
 	RET=$?
 fi
 
-if [ $RET -ne 0 ]; then
-	# Make sure user gets an email about this
+if [ -z "${NOTIFYONRETURN}" -a $RET -ne 0 ] || [[ "${NOTIFYONRETURN}" == *$RET* ]] ; then
+	# Make sure user gets an email about this (when not success or if user has specified when)
 	cat ${LOGFILE} >&2
 fi
 

--- a/extras/cronwrapper
+++ b/extras/cronwrapper
@@ -14,10 +14,6 @@
 # LOGGING if true, logs all output to syslog daemon facility
 #         (typically /var/log/daemon.log or /var/log/syslog)
 #
-# NOTIFYONRETURN is used to define which return codes from plexupdate
-#                that you want to be notified for. By default, all
-#                non-zero return codes produce a notification.
-#
 
 if [ ! -f /etc/plexupdate.cron.conf ]; then
 	echo "ERROR: You have not configured /etc/plexupdate.cron.conf" >&2
@@ -59,7 +55,7 @@ else
 	RET=$?
 fi
 
-if [ -z "${NOTIFYONRETURN}" -a $RET -ne 0 ] || [[ "${NOTIFYONRETURN}" == *$RET* ]] ; then
+if [ $RET -ne 0 ] ; then
 	# Make sure user gets an email about this (when not success or if user has specified when)
 	cat ${LOGFILE} >&2
 fi

--- a/extras/cronwrapper
+++ b/extras/cronwrapper
@@ -59,12 +59,9 @@ else
 	RET=$?
 fi
 
-if [ $RET -ne 2 -a $RET -ne 5 ]; then
+if [ $RET -ne 0 ]; then
 	# Make sure user gets an email about this
 	cat ${LOGFILE} >&2
-else
-	# Nah, not important
-	RET=0
 fi
 
 rm "${LOGFILE}" 2>/dev/null

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -24,7 +24,6 @@
 #         2 if file already downloaded
 #         3 if page layout has changed.
 #         4 if download fails
-#         5 if version already installed
 #         6 if update was deferred due to usage
 #
 # All other return values not documented.
@@ -563,7 +562,7 @@ fi
 
 if [[ $FILENAME == *$INSTALLED_VERSION* ]] && [ "${FORCE}" != "yes" -a "${FORCEALL}" != "yes" ] && [ ! -z "${INSTALLED_VERSION}" ]; then
 	info "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
-	exit 5
+	exit 0
 fi
 
 if [ -f "${DOWNLOADDIR}/${FILENAME}" ]; then


### PR DESCRIPTION
- plexupdate.sh will consider no new version as success
- cronwrapper will not print anything unless it truly fails
- README.md updated to provide more details about .plexupdate