### PR TITLE
Simplify exit statuses

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -607,8 +607,7 @@ if [ "${SKIP_DOWNLOAD}" = "no" ]; then
 	info "File downloaded"
 fi
 
-sha1sum --status -c "${FILE_SHA}"
-if [ $? -ne 0 ]; then
+if ! sha1sum --status -c "${FILE_SHA}"; then
 	error "Downloaded file corrupt. Try again."
 	exit 4
 fi
@@ -628,6 +627,11 @@ if [ "${AUTOINSTALL}" = "yes" ]; then
 	# no elif since DISTRO_INSTALL will produce error output for us
 
 	${DISTRO_INSTALL} "${DOWNLOADDIR}/${FILENAME}"
+	RET=$?
+	if [ $RET -ne 0 ]; then
+		error "Error reported while installing ${FILENAME}."
+		exit $RET
+	fi
 fi
 
 if [ "${AUTODELETE}" = "yes" ]; then
@@ -656,4 +660,5 @@ if [ "${AUTOSTART}" = "yes" ]; then
 	fi
 fi
 
-exit 0
+# If we've made it this far and haven't exited it means an update was downloaded and/or installed
+exit 6

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -21,10 +21,8 @@
 #
 # Returns 0 on success
 #         1 on error
-#         2 if file already downloaded
-#         3 if page layout has changed.
-#         4 if download fails
-#         6 if update was deferred due to usage
+#         2 an update was found/installed
+#       255 an invalid parameter/combination was passed to plexupdate
 #
 # All other return values not documented.
 #
@@ -531,13 +529,13 @@ CHECKSUM=$(echo ${RELEASE} | grep -ioe '\"checksum\"\:\"[^\"]*' | sed 's/\"check
 
 if [ -z "${DOWNLOAD}" ]; then
 	error "Unable to retrieve the URL needed for download (Query DISTRO: $DISTRO, BUILD: $BUILD)"
-	exit 3
+	exit 1
 fi
 
 FILENAME="$(basename 2>/dev/null ${DOWNLOAD})"
 if [ $? -ne 0 ]; then
 	error "Failed to parse HTML, download cancelled."
-	exit 3
+	exit 1
 fi
 
 echo "${CHECKSUM}  ${DOWNLOADDIR}/${FILENAME}" >"${FILE_SHA}"
@@ -570,9 +568,6 @@ if [ -f "${DOWNLOADDIR}/${FILENAME}" ]; then
 		sha1sum --status -c "${FILE_SHA}"
 		if [ $? -eq 0 ]; then
 			info "File already exists (${FILENAME}), won't download."
-			if [ "${AUTOINSTALL}" != "yes" ]; then
-				exit 2
-			fi
 			SKIP_DOWNLOAD="yes"
 		else
 			info "File exists but fails checksum. Redownloading."
@@ -609,14 +604,14 @@ fi
 
 if ! sha1sum --status -c "${FILE_SHA}"; then
 	error "Downloaded file corrupt. Try again."
-	exit 4
+	exit 1
 fi
 
 if [ ! -z "${PLEXSERVER}" -a "${AUTOINSTALL}" = "yes" ]; then
 	# Check if server is in-use before continuing (thanks @AltonV, @hakong and @sufr3ak)...
 	if running ${PLEXSERVER} ${TOKEN} ${PLEXPORT}; then
 		error "Server ${PLEXSERVER} is currently being used by one or more users, skipping installation. Please run again later"
-		exit 6
+		exit 2
 	fi
 fi
 
@@ -661,4 +656,4 @@ if [ "${AUTOSTART}" = "yes" ]; then
 fi
 
 # If we've made it this far and haven't exited it means an update was downloaded and/or installed
-exit 6
+exit 2


### PR DESCRIPTION
This is just a proof-of-concept for #150. I intentionally split it up into two commits so that if we decide to use `exit 6` instead of simplifying everything down to exit codes 0-2, we can just revert e14a1a7.

I think the first part of this at least is a simple enough change that it can be implemented without causing any real disruption for existing users (except that their cron jobs will now start working the way they're supposed to). If you really want to simplify the exit codes, then e14a1a7 takes care of that piece as well, getting us down to just 3 real exit statuses (4, if you count exit 255 for invalid config options).