### PR TITLE
Fall back on server token

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -510,8 +510,6 @@ if [ "${PUBLIC}" = "no" ]; then
 	else
 		info "Using Plex Server credentials to authenticate"
 	fi
-fi
-
 elif [ "$PUBLIC" != "no" ]; then
 	# It's a public version, so change URL and make doubly sure that cookies are empty
 	rm 2>/dev/null >/dev/null "${FILE_KAKA}"


### PR DESCRIPTION
Fall back on the server token so that your plex password doesn't have to be stored in plain text at all for Plexpass updates.

Of course if the server isn't running, or isn't logged in the fall back won't work, so we still present `"Need username & password to download PlexPass version. Otherwise run with -p to download public version."` in that case.