### PR TITLE
Switch to using only tokens for plexupdate.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Here are some of the more useful ones:
 - `--port <Plex server port>`
   This is the port that Plex Media Server uses.
 
+# FAQ
+
+## Do I have to use the `extras/installer.sh`?
+
+Of course not, anything you find under `extras/` is optional and only provided as a easier way to get `plexupdate.sh` up and running quickly. [Read the guide](https://github.com/mrworf/plexupdate/wiki/Manually-installing-plexupdate) for installing plexupdate manually.
+
+## Why am I getting a warning about email and password being deprecated?
+
+Since just storing your password in plexupdate.conf isn't secure, plexupdate will now use a "token" instead. To make this warning just re-run the installer (`extras/installer.sh`) or manually remove `EMAIL` and `PASS` from your plexupdate.conf. For more details, see [this wiki article](https://github.com/mrworf/plexupdate/wiki/Authenticating-with-Plex-Pass).
+
 # Need more information?
 
 See https://github.com/mrworf/plexupdate/wiki for more information

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Here are some of the more useful ones:
 
 ## Do I have to use the `extras/installer.sh`?
 
-Of course not, anything you find under `extras/` is optional and only provided as a easier way to get `plexupdate.sh` up and running quickly. [Read the guide](https://github.com/mrworf/plexupdate/wiki/Manually-installing-plexupdate) for installing plexupdate manually.
+Of course not, anything you find under `extras/` is optional and only provided as an easier way to get `plexupdate.sh` up and running quickly. Read the guide for [installing plexupdate manually](https://github.com/mrworf/plexupdate/wiki/Manually-installing-plexupdate).
 
 ## Why am I getting a warning about email and password being deprecated?
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Plex Update is a bash script which helps you keep Plex Media Server up to date on Linux.
 
-You can schedule updates to run daily, and install Plex Pass beta releases if you have a Plex Pass membership.
+You can schedule updates to run daily and install Plex Pass beta releases if you have a Plex Pass membership.
 
 # Installation
 
@@ -23,30 +23,30 @@ If you have any trouble with the installer, or would just prefer to set plexupda
 
 There are a few additional options for the more enterprising user. Setting any of these to `yes` will enable the function.
 
-- CHECKUPDATE
+- `CHECKUPDATE`
   If you didn't install using `git clone` or by running the installer, you can use this option to notify you when there are updates to plexupdate. If you used git or the installer, see `AUTOUPDATE` instead.
-- PLEXSERVER
-  If set, and combined with AUTOINSTALL, the script will automatically check if the server is in use and defer the update. Great for crontab users. `PLEXSERVER` should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
-- PLEXPORT
+- `PLEXSERVER`
+  If set, and combined with `AUTOINSTALL`, the script will automatically check if the server is in use and defer the update. Great for crontab users. `PLEXSERVER` should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
+- `PLEXPORT`
   Sets the port to use along with `PLEXSERVER`
-- AUTOUPDATE
+- `AUTOUPDATE`
   Makes plexupdate.sh automatically update itself using git. This only works if you installed using `git clone` or by using the installer.
-- AUTOINSTALL
+- `AUTOINSTALL`
   Automatically installs the newly downloaded version. Currently works for Debian based systems as well as rpm based distros. Requires root permissions.
-- AUTODELETE
+- `AUTODELETE`
   Delete the downloaded package after installation is complete to conserve disk space.
-- PUBLIC
+- `PUBLIC`
   The default behavior of plexupdate.sh is to download the PlexPass edition of Plex Media Server. Setting this option to `yes` will make it download the public version instead.
-- FORCE
+- `FORCE`
   Normally plexupdate.sh will avoid downloading a file it already has or if it's the same as the installed version. Using this option will force it to download again UNLESS the file already downloaded has the correct checksum. If you have AUTOINSTALL set, plexupdate.sh will then reinstall it.
-- PRINT_URL
+- `PRINT_URL`
   Authenticate, fetch the download URL, print it, and then exit.
-- DISTRO_INSTALL
+- `DISTRO_INSTALL`
   The command used to install packages, only change if you need special options. Natively supports Debian and Redhat, so you don't need to set this for these systems.
-  NOTE! If you define this, you MUST define DISTRO and BUILD
-- DISTRO and BUILD
+  NOTE! If you define this, you MUST define `DISTRO` and `BUILD`
+- `DISTRO` and `BUILD`
   Override which version to download, use -l option to see what you can select.
-- TOKEN
+- `TOKEN`
   If you want to install Plex Pass releases, plexupdate will try to get your account token directly from your Plex Media Server. If you want to use a different token to authenticate, you can enter it here instead. Please read [Authenticating with Plex Pass](https://github.com/mrworf/plexupdate/wiki/Authenticating-with-Plex-Pass) on the wiki for more details.
 
 Most of these options can be specified on the command-line as well, this is just a more convenient way of doing it if you're scripting it. Which brings us to...

--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 
 Plex Update is a bash script which helps you keep Plex Media Server up to date on Linux.
 
-plexupdate will automatically download the latest version of Plex Media Server for Linux and, optionally, also install it for you.
-
-### What happened to `.plexupdate` ?
-
-It has gone away to keep things simpler and more secure. You can either provide the config you want using the `--config` parameter or place it in `/etc/plexupdate.conf`.
+You can schedule updates to run daily, and install Plex Pass beta releases if you have a Plex Pass membership.
 
 # Installation
 
@@ -19,109 +15,30 @@ bash -c "$(wget -qO - https://raw.githubusercontent.com/mrworf/plexupdate/master
 
 will automatically install the tool as well as any dependencies. This has been tested on Ubuntu, Fedora and CentOS but should, for the most part, work on any modern Linux distribution.
 
-If you'd ever like to change your configuration, you can just re-run this from the extras folder inside your plexupdate directory. (`/opt/plexupdate/extras/installer.sh` by default)
+If you'd ever like to change your configuration, just re-run the installer from the extras folder inside your plexupdate directory. (`/opt/plexupdate/extras/installer.sh` by default)
 
-If you have any trouble with the installer, or would just prefer to set plexupdate up manually, read on.
+If you have any trouble with the installer, or would just prefer to set plexupdate up manually, [read the guide](https://github.com/mrworf/plexupdate/wiki/Manually-installing-plexupdate).
 
-## 1. Getting the code
+# Advanced options
 
-####Using git to clone (recommended)
-```
-git clone https://github.com/mrworf/plexupdate.git
-```
-Note that git is required (`sudo apt-get install git`)
-
-This is the recommended way to install plexupdate. Using git allows you to know when a new version is available as well allowing plexupdate to keep itself up to date (with the AUTOUPDATE option).
-
-####Using wget and unzip
-
-Download it as a [zip file](https://github.com/mrworf/plexupdate/archive/master.zip) and unzip it on your server.
-```
-wget https://github.com/mrworf/plexupdate/archive/master.zip && unzip master.zip && mv plexupdate-master plexupdate && rm master.zip
-```
-Note that unzip is required (`sudo apt-get install unzip`).
-
-## 2. Setting it up
-
-In order to use `plexupdate.sh`, it's recommended you create a configuration file.
-
-```
-sudo nano -w /etc/plexupdate.conf
-```
-
-In the newly opened editor, insert the following (and make *sure* to change email and password)
-
-```
-EMAIL='john.doe@void.com'
-PASS='verySecretPassword'
-DOWNLOADDIR='/tmp/'
-```
-
-This will make `plexupdate.sh` login and download the latest version and save it to /tmp/ folder.
-
-If you don't have PlexPass, you can still use `plexupdate.sh`, just set `PUBLIC=yes` instead. The section above becomes
-
-```
-PUBLIC=yes
-DOWNLOADDIR='/tmp/'
-```
-
-## 3. Cronjob
-
-You might be more interested in running this on a regular basis. To accomplish this, we need to do the following. Locate the `extras` folder which was included with plexupdate. In this folder you'll find `cronwrapper`. You need to "symlink" this into `/etc/cron.daily/`. Symlink means we tell the system that there should be reference/link to the file included in plexupdate. By not copying, we will automatically get updates to the `cronwrapper` when we update plexupdate.
-
-When doing the symlink, it's important to provide the complete path to the file in question, so you will need to edit the path to it in the following snippet. Also, we need to run as root, since only root is allowed to edit files under `/etc`.
-
-```
-sudo ln -s /home/john/plexupdate/extras/cronwrapper /etc/cron.daily/plexupdate
-```
-
-We also need to tell cronwrapper where to find plexupdate, again, this needs to be done as root for the same reasons as above.
-
-```
-sudo nano -w /etc/plexupdate.cron.conf
-```
-
-In the new file, we simply point out the location of `plexupdate.sh` and `plexupdate.conf`
-
-```
-SCRIPT=/home/john/plexupdate/plexupdate.sh
-CONF=/home/john/plexupdate.conf
-```
-
-If you've installed it somewhere else and/or the path to the config is somewhere else, please *make sure* to write the correct paths.
-
-Almost done. Final step is to make `plexupdate.sh` a bit smarter and have it install the newly downloaded version, so open the `plexupdate.conf` file you created previously and add the following:
-
-```
-AUTOINSTALL=yes
-AUTODELETE=yes
-```
-
-This tells `plexupdate.sh` to install the file once downloaded and delete it when done, keeping your server nice and clean.
-
-## 4. Advanced options
-
-There are also a few additional options for the more enterprising user. Setting any of these to `yes` will enable the function.
+There are a few additional options for the more enterprising user. Setting any of these to `yes` will enable the function.
 
 - CHECKUPDATE
-  If set (and it is by default), it will compare your local copy with the one stored on github. If there is any difference, it will let you know. This is handy if you're not using `git clone` but want to be alerted to new versions.
+  If you didn't install using `git clone` or by running the installer, you can use this option to notify you when there are updates to plexupdate. If you used git or the installer, see `AUTOUPDATE` instead.
 - PLEXSERVER
-  If set, and combined with AUTOINSTALL, the script will automatically check if the server is in-use and defer the update. Great for crontab users. PLEXSERVER should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
+  If set, and combined with AUTOINSTALL, the script will automatically check if the server is in use and defer the update. Great for crontab users. `PLEXSERVER` should be set to the IP/DNS of your Plex Media Server, which typically is 127.0.0.1
 - PLEXPORT
-  Sets the port to use along with PLEXSERVER
+  Sets the port to use along with `PLEXSERVER`
 - AUTOUPDATE
-  Makes plexupdate.sh automatically update itself using git. Note! This will fail if git isn't available on the command line.
+  Makes plexupdate.sh automatically update itself using git. This only works if you installed using `git clone` or by using the installer.
 - AUTOINSTALL
-  Automatically installs the newly downloaded version. Currently works for Debian based systems as well as rpm based distros. Will fail miserably if you're not root.
+  Automatically installs the newly downloaded version. Currently works for Debian based systems as well as rpm based distros. Requires root permissions.
 - AUTODELETE
-  Once successfully downloaded and installed, it will delete the package (want not, waste not? ;-))
+  Delete the downloaded package after installation is complete to conserve disk space.
 - PUBLIC
-  The default behavior of plexupdate.sh is to download the PlexPass edition of Plex Media Server. Setting this option to `yes` will make it download the public version instead. If this is yes, then `EMAIL` and `PASS` is no longer needed.
+  The default behavior of plexupdate.sh is to download the PlexPass edition of Plex Media Server. Setting this option to `yes` will make it download the public version instead.
 - FORCE
   Normally plexupdate.sh will avoid downloading a file it already has or if it's the same as the installed version. Using this option will force it to download again UNLESS the file already downloaded has the correct checksum. If you have AUTOINSTALL set, plexupdate.sh will then reinstall it.
-- FORCEALL
-  Using this option will force plexupdate.sh to override the checksum check and will download the file again, and if you have AUTOINSTALL set, will reinstall it.
 - PRINT_URL
   Authenticate, fetch the download URL, print it, and then exit.
 - DISTRO_INSTALL
@@ -129,21 +46,19 @@ There are also a few additional options for the more enterprising user. Setting 
   NOTE! If you define this, you MUST define DISTRO and BUILD
 - DISTRO and BUILD
   Override which version to download, use -l option to see what you can select.
+- TOKEN
+  If you want to install Plex Pass releases, plexupdate will try to get your account token directly from your Plex Media Server. If you want to use a different token to authenticate, you can enter it here instead. Please read [Authenticating with Plex Pass](https://github.com/mrworf/plexupdate/wiki/Authenticating-with-Plex-Pass) on the wiki for more details.
 
 Most of these options can be specified on the command-line as well, this is just a more convenient way of doing it if you're scripting it. Which brings us to...
 
-### Command Line Options
+## Command Line Options
 
-Plexupdate comes with many command line options. For the most up-to-date list, I'd recommend you run plexupdate.sh with -h
+Plexupdate comes with many command line options. For the most up-to-date list, run plexupdate.sh with -h
 
-But here are some of the more useful ones:
+Here are some of the more useful ones:
 
 - `--config <path/to/config/file>`
   Defines the location the script should look for the config file.
-- `--email <Plex.tv email>`
-  Email to sign in to Plex.tv
-- `--pass <Plex.tv password>`
-  Password to sign in to Plex.tv
 - `--dldir <path/to/where/you/want/files/downloaded/to>`
   This is the folder that the files will be downloaded to.
 - `--server <Plex server address>`
@@ -151,32 +66,6 @@ But here are some of the more useful ones:
 - `--port <Plex server port>`
   This is the port that Plex Media Server uses.
 
-# Trivia
-
-- "kaka" is Swedish for "cookie"
-
-# FAQ
-
-## Where is `.plexupdate`
-
-See explanation in the top of this document.
-
-## Do I have to use the `extras/installer.sh` ?
-
-Of course not, anything you find under `extras/` is optional and only provided as a easier way to get `plexupdate.sh` up and running quickly.
-
-## What email and password are you talking about
-
-The email and password for http://plex.tv
-
-## My password is rejected even though correct
-
-If you use certain characters (such as `$`) in your password, bash will interpret that as a reference to a variable. To resolve this, enclose your password within single quotes (`'`) instead of the normal quotes (`"`).
-
-i.e. `PASS="MyP4$$w0rD"` will not work, but changing to it to `PASS='MyP4$$w0rD'` will
-
-If it's still not working, run `plexupdate.sh` with `-v` which prints out the email and password used to login which might help you understand what the problem is.
-
-# Not finding what you're looking for?
+# Need more information?
 
 See https://github.com/mrworf/plexupdate/wiki for more information

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Of course not, anything you find under `extras/` is optional and only provided a
 
 ## Why am I getting a warning about email and password being deprecated?
 
-Since just storing your password in plexupdate.conf isn't secure, plexupdate will now use a "token" instead. To make this warning just re-run the installer (`extras/installer.sh`) or manually remove `EMAIL` and `PASS` from your plexupdate.conf. For more details, see [this wiki article](https://github.com/mrworf/plexupdate/wiki/Authenticating-with-Plex-Pass).
+Since just storing your password in plexupdate.conf isn't secure, plexupdate will now use a "token" instead. To make this warning go away just re-run the installer (`extras/installer.sh`) or manually remove `EMAIL` and `PASS` from your plexupdate.conf. For more details, see [this wiki article](https://github.com/mrworf/plexupdate/wiki/Authenticating-with-Plex-Pass).
 
 # Need more information?
 

--- a/extras/cronwrapper
+++ b/extras/cronwrapper
@@ -58,6 +58,11 @@ fi
 if [ $RET -ne 0 ] ; then
 	# Make sure user gets an email about this (when not success or if user has specified when)
 	cat ${LOGFILE} >&2
+
+	# Output will produce a cron email, so we can reset the exit status
+	if [ $RET -eq 10 ]; then
+		RET=0
+	fi
 fi
 
 rm "${LOGFILE}" 2>/dev/null

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -5,7 +5,11 @@ URL_LOGIN='https://plex.tv/users/sign_in.json'
 getPlexToken() {
 	#getPlexServerToken
 	# Check if we're connected to a terminal
-	if [ -z "$TOKEN" -a -t 0 ]; then
+	if [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
+		#TOFIX
+		echo "WARNING: Storing your email and password has been deprecated. Please re-run extras/installer.sh or see LINK_TO_FAQ."
+		getPlexWebToken
+	elif [ -z "$TOKEN" -a -t 0 ]; then
 		echo "To continue, you will need to provide your Plex account credentials."
 		echo "Your email and password will only be used to retrieve a 'token' and will not be saved anywhere."
 		echo

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -33,7 +33,7 @@ getPlexToken() {
 	elif [ -n "$TOKEN" ]; then
 		echo "Fetching token from Plex server"
 	fi
-	
+
 	[ -n "$TOKEN" ] # simulate exit status
 }
 

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -74,7 +74,8 @@ getPlexServerToken() {
 
 	for I in "${VALIDPATHS[@]}" ; do
 		if [ ! -z "${I}" -a -f "${I}${PREFFILE}" ]; then
-			if [ "$(basename $0)" = "installer.sh" ]; then
+			# When running installer.sh directly from wget, $0 will return bash
+			if [ "$(basename $0)" = "installer.sh" -o "$(basename $0)" = "bash" ]; then
 				TOKEN=$(sudo sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
 			else
 				TOKEN=$(sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -5,7 +5,7 @@ URL_LOGIN='https://plex.tv/users/sign_in.json'
 getPlexToken() {
 	if [ -n "$TOKEN" ]; then
 		echo "Fetching token from config"
-	elif getPlexServerToken
+	elif getPlexServerToken; then
 		echo "Fetching token from Plex server"
 	elif [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
 		#TOFIX

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -3,12 +3,15 @@
 URL_LOGIN='https://plex.tv/users/sign_in.json'
 
 getPlexToken() {
-	[ -z "$TOKEN" ] && getPlexServerToken
-	# Check if we're connected to a terminal
-	if [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
+	if [ -n "$TOKEN" ]; then
+		echo "Fetching token from config"
+	elif getPlexServerToken
+		echo "Fetching token from Plex server"
+	elif [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
 		#TOFIX
 		echo "WARNING: Storing your email and password has been deprecated. Please re-run extras/installer.sh or see LINK_TO_FAQ."
 		getPlexWebToken
+	# Check if we're connected to a terminal
 	elif [ -z "$TOKEN" -a -t 0 ]; then
 		echo "To continue, you will need to provide your Plex account credentials."
 		echo "Your email and password will only be used to retrieve a 'token' and will not be saved anywhere."
@@ -30,8 +33,6 @@ getPlexToken() {
 			fi
 		done
 		getPlexWebToken
-	elif [ -n "$TOKEN" ]; then
-		echo "Fetching token from Plex server"
 	fi
 
 	[ -n "$TOKEN" ] # simulate exit status
@@ -80,6 +81,8 @@ getPlexServerToken() {
 			fi
 		fi
 	done
+
+	[ -n "$TOKEN" ] # simulate exit status
 }
 
 getPlexWebToken() {

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -4,9 +4,9 @@ URL_LOGIN='https://plex.tv/users/sign_in.json'
 
 getPlexToken() {
 	if [ -n "$TOKEN" ]; then
-		echo "Fetching token from config"
+		[ "$VERBOSE" = "yes" ] && echo "Fetching token from config"
 	elif getPlexServerToken; then
-		echo "Fetching token from Plex server"
+		[ "$VERBOSE" = "yes" ] && echo "Fetching token from Plex server"
 	elif [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
 		#TOFIX
 		echo "WARNING: Storing your email and password has been deprecated. Please re-run extras/installer.sh or see LINK_TO_FAQ."
@@ -121,6 +121,8 @@ getPlexWebToken() {
 
 	# Clean up temp files since they may contain sensitive information
 	rm "${FILE_FAILCAUSE}" "${FILE_POSTDATA}" "${FILE_RAW}"
+
+	[ -n "$TOKEN" ] # simulate exit status
 }
 
 if [ "$(basename "$0")" = "get-plex-token" ]; then

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -3,7 +3,7 @@
 URL_LOGIN='https://plex.tv/users/sign_in.json'
 
 getPlexToken() {
-	#getPlexServerToken
+	[ -z "$TOKEN" ] && getPlexServerToken
 	# Check if we're connected to a terminal
 	if [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
 		#TOFIX

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+URL_LOGIN='https://plex.tv/users/sign_in.json'
+
+getPlexToken() {
+	#getPlexServerToken
+	# Check if we're connected to a terminal
+	if [ -z "$TOKEN" -a -t 0 ]; then
+		echo "To continue, you will need to provide your Plex account credentials."
+		echo "Your email and password will only be used to retrieve a 'token' and will not be saved anywhere."
+		echo
+		while true; do
+			read -e -p "PlexPass Email Address: " -i "$EMAIL" EMAIL
+			if [ -z "${EMAIL}" ] || [[ "$EMAIL" == *"@"* ]] && [[ "$EMAIL" != *"@"*"."* ]]; then
+				echo "Please provide a valid email address"
+			else
+				break
+			fi
+		done
+		while true; do
+			read -e -p "PlexPass Password: " -i "$PASS" PASS
+			if [ -z "$PASS" ]; then
+				echo "Please provide a password"
+			else
+				break
+			fi
+		done
+		getPlexWebToken
+	elif [ -n "$TOKEN" ]; then
+		echo "Fetching token from Plex server"
+	fi
+	
+	[ -n "$TOKEN" ] # simulate exit status
+}
+
+# Useful functions
+keypair() {
+	local key="$( rawurlencode "$1" )"
+	local val="$( rawurlencode "$2" )"
+
+	echo "${key}=${val}"
+}
+
+rawurlencode() {
+	local string="${1}"
+	local strlen=${#string}
+	local encoded=""
+
+	for (( pos=0 ; pos<strlen ; pos++ )); do
+		c=${string:$pos:1}
+		case "$c" in
+		[-_.~a-zA-Z0-9] ) o="${c}" ;;
+		* )               printf -v o '%%%02x' "'$c"
+		esac
+		encoded+="${o}"
+	done
+	echo "${encoded}"
+}
+
+# Worker functions
+getPlexServerToken() {
+	if [ -f /etc/default/plexmediaserver ]; then
+		source /etc/default/plexmediaserver
+	fi
+
+	# List possible locations to find Plex Server preference file
+	local VALIDPATHS=("${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}" "/var/lib/plexmediaserver/Library/Application Support/" "${HOME}/Library/Application Support/")
+	local PREFFILE="/Plex Media Server/Preferences.xml"
+
+	for I in "${VALIDPATHS[@]}" ; do
+		if [ ! -z "${I}" -a -f "${I}${PREFFILE}" ]; then
+			TOKEN=$(sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
+		fi
+	done
+}
+
+getPlexWebToken() {
+	FILE_POSTDATA=$(mktemp /tmp/plexupdate.postdata.XXXX)
+	FILE_RAW=$(mktemp /tmp/plexupdate.raw.XXXX)
+	FILE_FAILCAUSE=$(mktemp /tmp/plexupdate.failcause.XXXX)
+
+	# Fields we need to submit for login to work
+	#
+	# Field			Value
+	# utf8			&#x2713;
+	# authenticity_token	<Need to be obtained from web page>
+	# user[login]		$EMAIL
+	# user[password]	$PASS
+	# user[remember_me]	0
+	# commit		Sign in
+
+	# Build post data
+	echo -ne >"${FILE_POSTDATA}" "$(keypair "user[login]" "${EMAIL}" )"
+	echo -ne >>"${FILE_POSTDATA}" "&$(keypair "user[password]" "${PASS}" )"
+	echo -ne >>"${FILE_POSTDATA}" "&$(keypair "user[remember_me]" "0" )"
+
+	# Authenticate (using Plex Single Sign On)
+	wget --header "X-Plex-Client-Identifier: 4a745ae7-1839-e44e-1e42-aebfa578c865" --header "X-Plex-Product: Plex SSO" "${URL_LOGIN}" --post-file="${FILE_POSTDATA}" -q -S -O "${FILE_FAILCAUSE}" 2>"${FILE_RAW}"
+
+	# Provide some details to the end user
+	RESULTCODE=$(head -n1 "${FILE_RAW}" | grep -oe '[1-5][0-9][0-9]')
+	if [ $RESULTCODE -eq 401 ]; then
+		echo "ERROR: Username and/or password incorrect" >&2
+	elif [ $RESULTCODE -ne 201 ]; then
+		echo "ERROR: Failed to log in, debug information:" >&2
+		cat "${FILE_RAW}" >&2
+	else
+		TOKEN=$(<"${FILE_FAILCAUSE}"  grep -ioe '"authToken":"[^"]*' | cut -c 14-)
+	fi
+
+	# Clean up temp files since they may contain sensitive information
+	rm "${FILE_FAILCAUSE}" "${FILE_POSTDATA}" "${FILE_RAW}"
+}
+
+if [ "$(basename "$0")" = "get-plex-token" ]; then
+	[ -f /etc/plexupdate.conf ] && source /etc/plexupdate.conf
+	getPlexToken && echo "Token = $TOKEN"
+fi

--- a/extras/get-plex-token
+++ b/extras/get-plex-token
@@ -73,7 +73,11 @@ getPlexServerToken() {
 
 	for I in "${VALIDPATHS[@]}" ; do
 		if [ ! -z "${I}" -a -f "${I}${PREFFILE}" ]; then
-			TOKEN=$(sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
+			if [ "$(basename $0)" = "installer.sh" ]; then
+				TOKEN=$(sudo sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
+			else
+				TOKEN=$(sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
+			fi
 		fi
 	done
 }

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ORIGIN_REPO="https://github.com/mrworf/plexupdate"
+ORIGIN_REPO="https://github.com/${GIT_OWNER:-mrworf}/plexupdate"
 FULL_PATH="/opt/plexupdate"
 CONFIGFILE="/etc/plexupdate.conf"
 CONFIGCRON="/etc/plexupdate.cron.conf"
@@ -153,7 +153,7 @@ configure_plexupdate() {
 	fi
 	if yesno $default; then
 		PUBLIC=no
-		source get-plex-token
+		source "${FULL_PATH}/get-plex-token"
 		getPlexToken
 		if [ -z "$TOKEN" ]; then
 			abort "Failed to retrieve Plex token, please try again."

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -12,7 +12,7 @@ AUTOUPDATE=yes
 PUBLIC=
 
 # variables to save in config
-CONFIGVARS="AUTOINSTALL AUTODELETE DOWNLOADDIR EMAIL PASS FORCE FORCEALL PUBLIC AUTOSTART AUTOUPDATE PLEXSERVER PLEXPORT CHECKUPDATE NOTIFY"
+CONFIGVARS="AUTOINSTALL AUTODELETE DOWNLOADDIR TOKEN FORCE FORCEALL PUBLIC AUTOSTART AUTOUPDATE PLEXSERVER PLEXPORT CHECKUPDATE NOTIFY"
 CRONVARS="CONF SCRIPT LOGGING"
 
 install() {
@@ -153,26 +153,16 @@ configure_plexupdate() {
 	fi
 	if yesno $default; then
 		PUBLIC=no
-		while true; do
-			read -e -p "PlexPass Email Address: " -i "$EMAIL" EMAIL
-			if [ -z "${EMAIL}" ] || [[ "$EMAIL" == *"@"* ]] && [[ "$EMAIL" != *"@"*"."* ]]; then
-				echo "Please provide a valid email address"
-			else
-				break
-			fi
-		done
-		while true; do
-			read -e -p "PlexPass Password: " -i "$PASS" PASS
-			if [ -z "$PASS" ]; then
-				echo "Please provide a password"
-			else
-				break
-			fi
-		done
+		source get-plex-token
+		getPlexToken
+		if [ -z "$TOKEN" ]; then
+			abort "Failed to retrieve Plex token, please try again."
+		fi
 	else
 		# don't forget to erase old settings if they changed their answer
 		EMAIL=
 		PASS=
+		TOKEN=
 		PUBLIC=yes
 	fi
 

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -154,7 +154,7 @@ configure_plexupdate() {
 	fi
 	if yesno $default; then
 		PUBLIC=no
-		source "${FULL_PATH}/extras/get-plex-token"
+		source "${FULL_PATH}/plexupdate-core"
 		getPlexToken
 		if [ -z "$TOKEN" ]; then
 			abort "Failed to retrieve Plex token, please try again."

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -147,17 +147,21 @@ configure_plexupdate() {
 	[ -f "$CONFIGFILE" ] && source "$CONFIGFILE"
 
 	echo
-	echo -n "Do you want to install the latest PlexPass releases? (requires PlexPass username and password) "
+	echo -n "Do you want to install the latest PlexPass releases? (requires PlexPass account) "
 	# The answer to this question and the value of PUBLIC are basically inverted
 	if [ "$PUBLIC" == "yes" ]; then
 		default=N
 	fi
 	if yesno $default; then
 		PUBLIC=no
-		source "${FULL_PATH}/plexupdate-core"
-		getPlexToken
-		if [ -z "$TOKEN" ]; then
-			abort "Failed to retrieve Plex token, please try again."
+		# If they already have a VALID token, leave it alone
+		if [ -z "$TOKEN" ] || ! verifyToken;
+			if getPlexServerToken; then
+				# Only store the token if it's not in PMS
+				TOKEN=
+			else
+				getPlexToken
+			fi
 		fi
 	else
 		# don't forget to erase old settings if they changed their answer
@@ -336,7 +340,7 @@ else
 	install_plexupdate
 fi
 
-
+source "${FULL_PATH}/plexupdate-core"
 
 configure_plexupdate
 configure_cron

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -159,8 +159,9 @@ configure_plexupdate() {
 			if getPlexServerToken; then
 				# Only store the token if it's not in PMS
 				TOKEN=
-			else
-				getPlexToken
+			elif ! getPlexToken; then
+				error "Unable to get Plex token, falling back to pulic release"
+				PUBLIC=yes
 			fi
 		fi
 	else

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -5,6 +5,7 @@ FULL_PATH="/opt/plexupdate"
 CONFIGFILE="/etc/plexupdate.conf"
 CONFIGCRON="/etc/plexupdate.cron.conf"
 CRONWRAPPER="/etc/cron.daily/plexupdate"
+VERBOSE=yes #to be inherited by get-plex-token, do not save to config
 
 # default options
 AUTOINSTALL=yes

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -347,7 +347,7 @@ if yesno; then
 		PROGRESS_OPT="-P"
 	fi
 	if [ "$AUTOINSTALL" == "yes" ]; then
-		sudo "$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"
+		sudo -E "$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"
 	else
 		"$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"
 	fi

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -153,7 +153,7 @@ configure_plexupdate() {
 	fi
 	if yesno $default; then
 		PUBLIC=no
-		source "${FULL_PATH}/get-plex-token"
+		source "${FULL_PATH}/extras/get-plex-token"
 		getPlexToken
 		if [ -z "$TOKEN" ]; then
 			abort "Failed to retrieve Plex token, please try again."

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -136,7 +136,7 @@ install_plexupdate() {
 		cd - &> /dev/null
 	else
 		echo -n "Installing plexupdate into '$FULL_PATH'... "
-		git clone "$ORIGIN_REPO" "$FULL_PATH" &> /dev/null || abort "install failed, cannot continue"
+		git clone --branch "${BRANCHNAME:-master}" "$ORIGIN_REPO" "$FULL_PATH" &> /dev/null || abort "install failed, cannot continue"
 		echo "done"
 	fi
 }

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -155,7 +155,7 @@ configure_plexupdate() {
 	if yesno $default; then
 		PUBLIC=no
 		# If they already have a VALID token, leave it alone
-		if [ -z "$TOKEN" ] || ! verifyToken;
+		if [ -z "$TOKEN" ] || ! verifyToken; then
 			if getPlexServerToken; then
 				# Only store the token if it's not in PMS
 				TOKEN=

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -200,6 +200,10 @@ running() {
 	fi
 }
 
+verifyToken() {
+	wget -qO /dev/null "https://plex.tv/api/resources?X-Plex-Token=${TOKEN}"
+}
+
 # Shared functions
 
 # SHARED

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -35,8 +35,7 @@ getPlexToken() {
 	elif getPlexServerToken; then
 		[ "$VERBOSE" = "yes" ] && info "Fetching token from Plex server"
 	elif [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
-		#TOFIX
-		warn "Storing your email and password has been deprecated. Please re-run extras/installer.sh or see LINK_TO_FAQ."
+		warn "Storing your email and password has been deprecated. Please re-run extras/installer.sh or see https://github.com/mrworf/plexupdate#faq"
 		getPlexWebToken
 	# Check if we're connected to a terminal
 	elif [ -z "$TOKEN" -a -t 0 ]; then

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -1,7 +1,34 @@
 #!/bin/bash
+######## INDEX ########
+# GPT -> getPlexToken
+# GPS -> getPlexServerToken
+# GPW -> getPlexWebToken
+# HELPERS -> keypair, rawurlencode, trimQuotes
+# RNNG -> running
+# SHARED -> warn, info, warn
 
+######## CONSTANTS ########
+# Current pages we need - Do not change unless Plex.tv changes again
 URL_LOGIN='https://plex.tv/users/sign_in.json'
+URL_DOWNLOAD='https://plex.tv/api/downloads/1.json?channel=plexpass'
+URL_DOWNLOAD_PUBLIC='https://plex.tv/api/downloads/1.json'
 
+# Default options for package managers, override if needed
+REDHAT_INSTALL="dnf -y install"
+DEBIAN_INSTALL="dpkg -i"
+DISTRO_INSTALL=""
+
+#URL for new version check
+UPSTREAM_GIT_URL="https://raw.githubusercontent.com/${GIT_OWNER:-mrworf}/plexupdate/${BRANCHNAME:-master}/plexupdate.sh"
+
+#Files "owned" by plexupdate, for autoupdate
+PLEXUPDATE_FILES="plexupdate.sh plexupdate-core extras/installer.sh extras/cronwrapper"
+
+
+######## FUNCTIONS ########
+#### Token Management #####
+
+# GPT
 getPlexToken() {
 	if [ -n "$TOKEN" ]; then
 		[ "$VERBOSE" = "yes" ] && echo "Fetching token from config"
@@ -38,31 +65,7 @@ getPlexToken() {
 	[ -n "$TOKEN" ] # simulate exit status
 }
 
-# Useful functions
-keypair() {
-	local key="$( rawurlencode "$1" )"
-	local val="$( rawurlencode "$2" )"
-
-	echo "${key}=${val}"
-}
-
-rawurlencode() {
-	local string="${1}"
-	local strlen=${#string}
-	local encoded=""
-
-	for (( pos=0 ; pos<strlen ; pos++ )); do
-		c=${string:$pos:1}
-		case "$c" in
-		[-_.~a-zA-Z0-9] ) o="${c}" ;;
-		* )               printf -v o '%%%02x' "'$c"
-		esac
-		encoded+="${o}"
-	done
-	echo "${encoded}"
-}
-
-# Worker functions
+# GPS
 getPlexServerToken() {
 	if [ -f /etc/default/plexmediaserver ]; then
 		source /etc/default/plexmediaserver
@@ -86,6 +89,7 @@ getPlexServerToken() {
 	[ -n "$TOKEN" ] # simulate exit status
 }
 
+# GPW
 getPlexWebToken() {
 	FILE_POSTDATA=$(mktemp /tmp/plexupdate.postdata.XXXX)
 	FILE_RAW=$(mktemp /tmp/plexupdate.raw.XXXX)
@@ -125,6 +129,83 @@ getPlexWebToken() {
 
 	[ -n "$TOKEN" ] # simulate exit status
 }
+
+# HELPERS
+keypair() {
+	local key="$( rawurlencode "$1" )"
+	local val="$( rawurlencode "$2" )"
+
+	echo "${key}=${val}"
+}
+
+rawurlencode() {
+	local string="${1}"
+	local strlen=${#string}
+	local encoded=""
+
+	for (( pos=0 ; pos<strlen ; pos++ )); do
+		c=${string:$pos:1}
+		case "$c" in
+		[-_.~a-zA-Z0-9] ) o="${c}" ;;
+		* )               printf -v o '%%%02x' "'$c"
+		esac
+		encoded+="${o}"
+	done
+	echo "${encoded}"
+}
+
+trimQuotes() {
+	local __buffer=$1
+
+	# Remove leading single quote
+	__buffer=${__buffer#\'}
+	# Remove ending single quote
+	__buffer=${__buffer%\'}
+
+	echo $__buffer
+}
+
+# RNNG
+running() {
+	local DATA="$(wget --no-check-certificate -q -O - https://$1:$3/status/sessions?X-Plex-Token=$2)"
+	local RET=$?
+	if [ ${RET} -eq 0 ]; then
+		if [ -z "${DATA}" ]; then
+			# Odd, but usually means noone is watching
+			return 1
+		fi
+		echo "${DATA}" | grep -q '<MediaContainer size="0">'
+		if [ $? -eq 1 ]; then
+			# not found means that one or more medias are being played
+			return 0
+		fi
+		return 1
+	elif [ ${RET} -eq 4 ]; then
+		# No response, assume not running
+		return 1
+	else
+		# We do not know what this means...
+		warn "Unknown response (${RET}) from server >>>"
+		warn "${DATA}"
+		return 0
+	fi
+}
+
+# Shared functions
+
+# SHARED
+warn() {
+	echo "WARNING: $@" >&1
+}
+
+info() {
+	echo "$@" >&1
+}
+
+error() {
+	echo "ERROR: $@" >&2
+}
+
 
 if [ "$(basename "$0")" = "get-plex-token" ]; then
 	[ -f /etc/plexupdate.conf ] && source /etc/plexupdate.conf

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -91,9 +91,9 @@ getPlexServerToken() {
 
 # GPW
 getPlexWebToken() {
-	FILE_POSTDATA=$(mktemp /tmp/plexupdate.postdata.XXXX)
-	FILE_RAW=$(mktemp /tmp/plexupdate.raw.XXXX)
-	FILE_FAILCAUSE=$(mktemp /tmp/plexupdate.failcause.XXXX)
+	local FILE_POSTDATA=$(mktemp /tmp/plexupdate.postdata.XXXX)
+	local FILE_RAW=$(mktemp /tmp/plexupdate.raw.XXXX)
+	local FILE_FAILCAUSE=$(mktemp /tmp/plexupdate.failcause.XXXX)
 
 	# Fields we need to submit for login to work
 	#
@@ -114,7 +114,7 @@ getPlexWebToken() {
 	wget --header "X-Plex-Client-Identifier: 4a745ae7-1839-e44e-1e42-aebfa578c865" --header "X-Plex-Product: Plex SSO" "${URL_LOGIN}" --post-file="${FILE_POSTDATA}" -q -S -O "${FILE_FAILCAUSE}" 2>"${FILE_RAW}"
 
 	# Provide some details to the end user
-	RESULTCODE=$(head -n1 "${FILE_RAW}" | grep -oe '[1-5][0-9][0-9]')
+	local RESULTCODE=$(head -n1 "${FILE_RAW}" | grep -oe '[1-5][0-9][0-9]')
 	if [ $RESULTCODE -eq 401 ]; then
 		error "Username and/or password incorrect"
 	elif [ $RESULTCODE -ne 201 ]; then
@@ -166,7 +166,10 @@ trimQuotes() {
 }
 
 getRemoteSHA() {
-	(wget -q "$1" -O - 2>/dev/null || return 1) | sha1sum | cut -f1 -d" "
+	# these two lines can't be combined. `local RESULT=` will gobble up the return
+	local RESULT
+	RESULT=$(wget -q "$1" -O - 2>/dev/null) || return 1
+	sha1sum <<< "$RESULT" | cut -f1 -d" "
 }
 
 getLocalSHA() {

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -19,7 +19,7 @@ DEBIAN_INSTALL="dpkg -i"
 DISTRO_INSTALL=""
 
 #URL for new version check
-UPSTREAM_GIT_URL="https://raw.githubusercontent.com/${GIT_OWNER:-mrworf}/plexupdate/${BRANCHNAME:-master}/plexupdate.sh"
+UPSTREAM_GIT_URL="https://raw.githubusercontent.com/${GIT_OWNER:-mrworf}/plexupdate/${BRANCHNAME:-master}"
 
 #Files "owned" by plexupdate, for autoupdate
 PLEXUPDATE_FILES="plexupdate.sh plexupdate-core extras/installer.sh extras/cronwrapper"
@@ -163,6 +163,15 @@ trimQuotes() {
 	__buffer=${__buffer%\'}
 
 	echo $__buffer
+}
+
+getRemoteSHA() {
+	(wget -q "$1" -O - 2>/dev/null || return 1) | sha1sum | cut -f1 -d" "
+}
+
+getLocalSHA() {
+	[ -f "$1" ] || return 1
+	sha1sum "$1" | cut -f1 -d" "
 }
 
 # RNNG

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -222,7 +222,7 @@ error() {
 	echo "ERROR: $@" >&2
 }
 
-
+# Intentionally leaving this hard to find so that people aren't trying to use it manually.
 if [ "$(basename "$0")" = "get-plex-token" ]; then
 	[ -f /etc/plexupdate.conf ] && source /etc/plexupdate.conf
 	getPlexToken && info "Token = $TOKEN"

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -31,22 +31,22 @@ PLEXUPDATE_FILES="plexupdate.sh plexupdate-core extras/installer.sh extras/cronw
 # GPT
 getPlexToken() {
 	if [ -n "$TOKEN" ]; then
-		[ "$VERBOSE" = "yes" ] && echo "Fetching token from config"
+		[ "$VERBOSE" = "yes" ] && info "Fetching token from config"
 	elif getPlexServerToken; then
-		[ "$VERBOSE" = "yes" ] && echo "Fetching token from Plex server"
+		[ "$VERBOSE" = "yes" ] && info "Fetching token from Plex server"
 	elif [ -z "$TOKEN" -a -n "$EMAIL" -a -n "$PASS" ]; then
 		#TOFIX
-		echo "WARNING: Storing your email and password has been deprecated. Please re-run extras/installer.sh or see LINK_TO_FAQ."
+		warn "Storing your email and password has been deprecated. Please re-run extras/installer.sh or see LINK_TO_FAQ."
 		getPlexWebToken
 	# Check if we're connected to a terminal
 	elif [ -z "$TOKEN" -a -t 0 ]; then
-		echo "To continue, you will need to provide your Plex account credentials."
-		echo "Your email and password will only be used to retrieve a 'token' and will not be saved anywhere."
+		info "To continue, you will need to provide your Plex account credentials."
+		info "Your email and password will only be used to retrieve a 'token' and will not be saved anywhere."
 		echo
 		while true; do
 			read -e -p "PlexPass Email Address: " -i "$EMAIL" EMAIL
 			if [ -z "${EMAIL}" ] || [[ "$EMAIL" == *"@"* ]] && [[ "$EMAIL" != *"@"*"."* ]]; then
-				echo "Please provide a valid email address"
+				info "Please provide a valid email address"
 			else
 				break
 			fi
@@ -54,7 +54,7 @@ getPlexToken() {
 		while true; do
 			read -e -p "PlexPass Password: " -i "$PASS" PASS
 			if [ -z "$PASS" ]; then
-				echo "Please provide a password"
+				info "Please provide a password"
 			else
 				break
 			fi
@@ -116,9 +116,9 @@ getPlexWebToken() {
 	# Provide some details to the end user
 	RESULTCODE=$(head -n1 "${FILE_RAW}" | grep -oe '[1-5][0-9][0-9]')
 	if [ $RESULTCODE -eq 401 ]; then
-		echo "ERROR: Username and/or password incorrect" >&2
+		error "Username and/or password incorrect"
 	elif [ $RESULTCODE -ne 201 ]; then
-		echo "ERROR: Failed to log in, debug information:" >&2
+		error "Failed to log in, debug information:"
 		cat "${FILE_RAW}" >&2
 	else
 		TOKEN=$(<"${FILE_FAILCAUSE}"  grep -ioe '"authToken":"[^"]*' | cut -c 14-)
@@ -218,5 +218,5 @@ error() {
 
 if [ "$(basename "$0")" = "get-plex-token" ]; then
 	[ -f /etc/plexupdate.conf ] && source /etc/plexupdate.conf
-	getPlexToken && echo "Token = $TOKEN"
+	getPlexToken && info "Token = $TOKEN"
 fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -409,8 +409,9 @@ if [ "${CHECKUPDATE}" = "yes" -a "${AUTOUPDATE}" = "no" ]; then
 	rm "${FILE_REMOTE}" 2>/dev/null >/dev/null
 fi
 
-if [ "${PUBLIC}" = "no" ]; then
-	[ -f extras/get-web-token ] && source extras/get-web-token
+if [ "${PUBLIC}" = "no" -a -z "$TOKEN" ]; then
+	TO_SOURCE="$(dirname "$0")/extras/get-web-token"
+	[ -f "$TO_SOURCE" ] && source $TO_SOURCE
 	if ! getPlexToken; then
 		error "Unable to get Plex token, falling back to public release"
 		PUBLiC="yes"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -339,7 +339,7 @@ if [ "${PUBLIC}" = "no" -a -z "$TOKEN" ]; then
 	[ -f "$TO_SOURCE" ] && source $TO_SOURCE
 	if ! getPlexToken; then
 		error "Unable to get Plex token, falling back to public release"
-		PUBLiC="yes"
+		PUBLIC="yes"
 	fi
 fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -87,12 +87,11 @@ usage() {
 	echo "    --check-update Check for new version of plex only"
 	echo "    --config <path/to/config/file> Configuration file to use"
 	echo "    --dldir <path/to/download/dir> Download directory to use"
-	echo "    --email <plex.tv email> Plex.TV email address"
 	echo "    --help This help"
 	echo "    --notify-success Set exit code 10 if update is available/installed"
-	echo "    --pass <plex.tv password> Plex.TV password"
 	echo "    --port <Plex server port> Port for Plex Server. Used with --server"
 	echo "    --server <Plex server address> Address of Plex Server"
+	echo "    --token Manually specify the token to use to download Plex Pass releases"
 	echo ""
 	exit 0
 }
@@ -110,7 +109,7 @@ trap cleanup EXIT
 
 # Parse commandline
 ALLARGS=( "$@" )
-optstring="-o acCdfFhlpPqrSsuUv -l config:,dldir:,email:,pass:,server:,port:,notify-success,check-update,help"
+optstring="-o acCdfFhlpPqrSsuUv -l config:,dldir:,email:,pass:,server:,port:,token:,notify-success,check-update,help"
 GETOPTRES=$(getopt $optstring -- "$@")
 if [ $? -eq 1 ]; then
 	exit 1
@@ -164,10 +163,11 @@ do
 
 		(--config) shift;; #gobble up the paramater and silently continue parsing
 		(--dldir) shift; DOWNLOADDIR=$(trimQuotes ${1});;
-		(--email) shift; EMAIL=$(trimQuotes ${1});;
-		(--pass) shift; PASS=$(trimQuotes ${1});;
+		(--email) shift; warn "EMAIL is deprecated. Use TOKEN instead."; EMAIL=$(trimQuotes ${1});;
+		(--pass) shift; warn "PASS is deprecated. Use TOKEN instead."; PASS=$(trimQuotes ${1});;
 		(--server) shift; PLEXSERVER=$(trimQuotes ${1});;
 		(--port) shift; PLEXPORT=$(trimQuotes ${1});;
+		(--token) shift; TOKEN=$(trimQuotes ${1});;
 		(--help) usage;;
 
 		(--notify-success) NOTIFY=yes;;

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -98,14 +98,15 @@ usage() {
 	echo "    -v Show additional debug information"
 	echo ""
 	echo "    Long Argument Options:"
+	echo "    --check-update Check for new version of plex only"
 	echo "    --config <path/to/config/file> Configuration file to use"
 	echo "    --dldir <path/to/download/dir> Download directory to use"
 	echo "    --email <plex.tv email> Plex.TV email address"
-	echo "    --pass <plex.tv password> Plex.TV password"
-	echo "    --server <Plex server address> Address of Plex Server"
-	echo "    --port <Plex server port> Port for Plex Server. Used with --server"
+	echo "    --help This help"
 	echo "    --notify-success Set exit code 10 if update is available/installed"
-	echo "    --check-update Check for new version of plex only"
+	echo "    --pass <plex.tv password> Plex.TV password"
+	echo "    --port <Plex server port> Port for Plex Server. Used with --server"
+	echo "    --server <Plex server address> Address of Plex Server"
 	echo ""
 	exit 0
 }
@@ -125,7 +126,7 @@ trap cleanup EXIT
 
 # Parse commandline
 ALLARGS=( "$@" )
-optstring="-o acCdfFhlpPqrSsuUv -l config:,dldir:,email:,pass:,server:,port:,notify-success,check-update"
+optstring="-o acCdfFhlpPqrSsuUv -l config:,dldir:,email:,pass:,server:,port:,notify-success,check-update,help"
 GETOPTRES=$(getopt $optstring -- "$@")
 if [ $? -eq 1 ]; then
 	exit 1
@@ -183,6 +184,7 @@ do
 		(--pass) shift; PASS=$(trimQuotes ${1});;
 		(--server) shift; PLEXSERVER=$(trimQuotes ${1});;
 		(--port) shift; PLEXPORT=$(trimQuotes ${1});;
+		(--help) usage;;
 
 		(--notify-success) NOTIFY=yes;;
 		(--check-update) CHECKONLY=yes;;

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -495,7 +495,7 @@ if [ "${CHECKONLY}" = "yes" ]; then
 		info "Your OS reports Plex $INSTALLED_VERSION installed, newer version is available (${AVAIL})"
 		exit 7
 	else
-		info "You are running latest version of Plex (${INSTALLED_VERSION})"
+		info "You are running the latest version of Plex (${INSTALLED_VERSION})"
 	fi
 	exit 0
 fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -6,17 +6,6 @@
 # Server for Linux. It supports both the public versions
 # as well as the PlexPass versions.
 #
-# PlexPass users:
-#   Create a plexupdate.conf file in your home directory with these
-#   values:
-#
-#   EMAIL='<whatever your plexpass email was>'
-#   PASS='<whatever password you used>'
-#   DOWNLOADDIR='<where you would like to save the downloaded package>'
-#
-# And run the tool using: ./plexupdate.sh --config plexupdate.conf
-# or place the config in /etc/plexupdate.conf
-#
 # See https://github.com/mrworf/plexupdate for more details.
 #
 # Returns 0 on success

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -324,7 +324,7 @@ if [ "${CHECKUPDATE}" = "yes" -a "${AUTOUPDATE}" = "no" ]; then
 	for filename in $PLEXUPDATE_FILES; do
 		[ -f "$filename" ] || error "Update check failed. '$filename' could not be found"
 
-		REMOTE_SHA=$(getRemoteSHA "$UPSTREAM_GIT_URL/$filename") || error "Update check failed. Unable to fetch '$UPSTREAM_GIT_URL/$filename'." 
+		REMOTE_SHA=$(getRemoteSHA "$UPSTREAM_GIT_URL/$filename") || error "Update check failed. Unable to fetch '$UPSTREAM_GIT_URL/$filename'."
 		LOCAL_SHA=$(getLocalSHA "$filename")
 		if [ "$REMOTE_SHA" != "$LOCAL_SHA" ]; then
 			info "Newer version of this script is available at https://github.com/${GIT_OWNER:-mrworf}/plexupdate"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -388,6 +388,12 @@ RELEASE=$(wget --header "X-Plex-Token:"${TOKEN}"" "${URL_DOWNLOAD}" -O - 2>/dev/
 DOWNLOAD=$(echo ${RELEASE} | grep -m1 -ioe 'https://[^\"]*')
 CHECKSUM=$(echo ${RELEASE} | grep -ioe '\"checksum\"\:\"[^\"]*' | sed 's/\"checksum\"\:\"//')
 
+if [ "$VERBOSE" = "yes" ]; then
+	for i in RELEASE DOWNLOAD CHECKSUM; do
+		info "$i=${!i}"
+	done
+fi
+
 if [ -z "${DOWNLOAD}" ]; then
 	error "Unable to retrieve the URL needed for download (Query DISTRO: $DISTRO, BUILD: $BUILD)"
 	if [ ! -z "${RELEASE}" ]; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -82,10 +82,7 @@ URL_DOWNLOAD='https://plex.tv/api/downloads/1.json?channel=plexpass'
 URL_DOWNLOAD_PUBLIC='https://plex.tv/api/downloads/1.json'
 
 #URL for new version check
-UPSTREAM_GIT_URL='https://raw.githubusercontent.com/mrworf/plexupdate/master/plexupdate.sh'
-
-#Branch to fetch updates from
-BRANCHNAME="master"
+UPSTREAM_GIT_URL="https://raw.githubusercontent.com/${GIT_OWNER:-mrworf}/plexupdate/${BRANCHNAME:-master}/plexupdate.sh"
 
 #Files "owned" by plexupdate, for autoupdate
 PLEXUPDATE_FILES="plexupdate.sh extras/installer.sh extras/cronwrapper"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -90,10 +90,6 @@ BRANCHNAME="master"
 #Files "owned" by plexupdate, for autoupdate
 PLEXUPDATE_FILES="plexupdate.sh extras/installer.sh extras/cronwrapper"
 
-FILE_POSTDATA=$(mktemp /tmp/plexupdate.postdata.XXXX)
-FILE_RAW=$(mktemp /tmp/plexupdate.raw.XXXX)
-FILE_FAILCAUSE=$(mktemp /tmp/plexupdate.failcause.XXXX)
-FILE_KAKA=$(mktemp /tmp/plexupdate.kaka.XXXX)
 FILE_SHA=$(mktemp /tmp/plexupdate.sha.XXXX)
 FILE_WGETLOG=$(mktemp /tmp/plexupdate.wget.XXXX)
 FILE_LOCAL=$(mktemp /tmp/plexupdate.local.XXXX)
@@ -182,53 +178,9 @@ trimQuotes() {
 	echo $__buffer
 }
 
-# Useful functions
-rawurlencode() {
-	local string="${1}"
-	local strlen=${#string}
-	local encoded=""
-
-	for (( pos=0 ; pos<strlen ; pos++ )); do
-		c=${string:$pos:1}
-		case "$c" in
-		[-_.~a-zA-Z0-9] ) o="${c}" ;;
-		* )               printf -v o '%%%02x' "'$c"
-		esac
-		encoded+="${o}"
-	done
-	echo "${encoded}"
-}
-
-keypair() {
-	local key="$( rawurlencode "$1" )"
-	local val="$( rawurlencode "$2" )"
-
-	echo "${key}=${val}"
-}
-
-getPlexServerToken() {
-	if [ -f /etc/default/plexmediaserver ]; then
-		source /etc/default/plexmediaserver
-	fi
-
-	# List possible locations to find Plex Server preference file
-	local VALIDPATHS=("${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}" "/var/lib/plexmediaserver/Library/Application Support/" "${HOME}/Library/Application Support/")
-	local PREFFILE="/Plex Media Server/Preferences.xml"
-
-	for I in "${VALIDPATHS[@]}" ; do
-		if [ ! -z "${I}" -a -f "${I}${PREFFILE}" ]; then
-			sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null
-			if [ $? -ne 0 -a -z "${EMAIL}" -a -z "${PASS}" ]; then
-				error "Do not have permission to read token from Plex Server preference file (${I}${PREFFILE})"
-			fi
-			exit 0
-		fi
-	done
-}
-
 # Setup an exit handler so we cleanup
 cleanup() {
-	for F in "${FILE_RAW}" "${FILE_FAILCAUSE}" "${FILE_POSTDATA}" "${FILE_KAKA}" "${FILE_SHA}" "${FILE_LOCAL}" "${FILE_REMOTE}" "${FILE_WGETLOG}"; do
+	for F in "${FILE_SHA}" "${FILE_LOCAL}" "${FILE_REMOTE}" "${FILE_WGETLOG}"; do
 		rm "$F" 2>/dev/null >/dev/null
 	done
 }
@@ -460,81 +412,21 @@ if [ "${CHECKUPDATE}" = "yes" -a "${AUTOUPDATE}" = "no" ]; then
 	rm "${FILE_REMOTE}" 2>/dev/null >/dev/null
 fi
 
-# Fields we need to submit for login to work
-#
-# Field			Value
-# utf8			&#x2713;
-# authenticity_token	<Need to be obtained from web page>
-# user[login]		$EMAIL
-# user[password]	$PASSWORD
-# user[remember_me]	0
-# commit		Sign in
-
 if [ "${PUBLIC}" = "no" ]; then
-	# Clean old session
-	rm "${FILE_KAKA}" 2>/dev/null
-  
-	# Try to obtain token from Plex Server Installation
-	TOKEN=
-	if [ -z "${EMAIL}" -o -z "${PASS}" ]; then
-		TOKEN=$(getPlexServerToken)
+	[ -f extras/get-web-token ] && source extras/get-web-token
+	if ! getPlexToken; then
+		error "Unable to get Plex token, falling back to public release"
+		PUBLiC="yes"
 	fi
+fi
 
-	if [ -z "${TOKEN}" ]; then
-		# If no token, go through regular process
-		if [ -z "${EMAIL}" -o -z "${PASS}" ]; then
-			error "Need username & password to download PlexPass version. Otherwise run with -p to download public version."
-			exit 1
-		elif [ ! -z "${EMAIL}" ] && [[ "$EMAIL" == *"@"* ]] && [[ "$EMAIL" != *"@"*"."* ]]; then
-			error "EMAIL field must contain a valid email address"
-			exit 1
-		elif [ ! -z "${EMAIL}" -a ! -z "${PASS}" -a "${PUBLIC}" = "yes" ]; then
-			warn "You have defined email and password but PUBLIC is set to yes, this will not download the PlexPass version"
-		fi  
-		info "Authenticating with plex.tv using email and password"
-
-		# Build post data
-		echo -ne >"${FILE_POSTDATA}" "$(keypair "user[login]" "${EMAIL}" )"
-		echo -ne >>"${FILE_POSTDATA}" "&$(keypair "user[password]" "${PASS}" )"
-		echo -ne >>"${FILE_POSTDATA}" "&$(keypair "user[remember_me]" "0" )"
-
-		# Authenticate (using Plex Single Sign On)
-		wget --header "X-Plex-Client-Identifier: 4a745ae7-1839-e44e-1e42-aebfa578c865" --header "X-Plex-Product: Plex SSO" --load-cookies "${FILE_KAKA}" --save-cookies "${FILE_KAKA}" --keep-session-cookies "${URL_LOGIN}" --post-file="${FILE_POSTDATA}" -q -S -O "${FILE_FAILCAUSE}" 2>"${FILE_RAW}"
-		# Delete authentication data ... Bad idea to let that stick around
-		rm "${FILE_POSTDATA}"
-
-		# Provide some details to the end user
-		RESULTCODE=$(head -n1 "${FILE_RAW}" | grep -oe '[1-5][0-9][0-9]')
-		if [ $RESULTCODE -eq 401 ]; then
-			error "Username and/or password incorrect"
-			if [ "$VERBOSE" = "yes" ]; then
-				info "Tried using \"${EMAIL}\" and \"${PASS}\" "
-			fi
-			exit 1
-		elif [ $RESULTCODE -ne 201 ]; then
-			error "Failed to login, debug information:"
-			cat "${FILE_RAW}" >&2
-			exit 1
-		fi
-
-		# If the system got here, it means the login was successfull, so we set the TOKEN variable to the authToken from the response
-		# I use cut -c 14- to cut off the "authToken":" string from the grepped result, can probably be done in a different way
-		TOKEN=$(<"${FILE_FAILCAUSE}"  grep -ioe '"authToken":"[^"]*' | cut -c 14-)
-
-		# Remove this, since it contains more information than we should leave hanging around
-		rm "${FILE_FAILCAUSE}"
-	else
-		info "Using Plex Server credentials to authenticate"
-	fi
-elif [ "$PUBLIC" != "no" ]; then
-	# It's a public version, so change URL and make doubly sure that cookies are empty
-	rm 2>/dev/null >/dev/null "${FILE_KAKA}"
-	touch "${FILE_KAKA}"
+if [ "$PUBLIC" != "no" ]; then
+	# It's a public version, so change URL
 	URL_DOWNLOAD=${URL_DOWNLOAD_PUBLIC}
 fi
 
 if [ "${LISTOPTS}" = "yes" ]; then
-	opts="$(wget --load-cookies "${FILE_KAKA}" --save-cookies "${FILE_KAKA}" --keep-session-cookies "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -oe '"label"[^}]*' | grep -v Download | sed 's/"label":"\([^"]*\)","build":"\([^"]*\)","distro":"\([^"]*\)".*/"\3" "\2" "\1"/' | uniq | sort)"
+	opts="$(wget "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -oe '"label"[^}]*' | grep -v Download | sed 's/"label":"\([^"]*\)","build":"\([^"]*\)","distro":"\([^"]*\)".*/"\3" "\2" "\1"/' | uniq | sort)"
 	eval opts=( "DISTRO" "BUILD" "DESCRIPTION" "======" "=====" "==============================================" $opts )
 
 	BUILD=
@@ -558,7 +450,7 @@ fi
 info "Retrieving list of available distributions"
 
 # Set "X-Plex-Token" to the auth token, if no token is specified or it is invalid, the list will return public downloads by default
-RELEASE=$(wget --header "X-Plex-Token:"${TOKEN}"" --load-cookies "${FILE_KAKA}" --save-cookies "${FILE_KAKA}" --keep-session-cookies "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -ioe '"label"[^}]*' | grep -i "\"distro\":\"${DISTRO}\"" | grep -m1 -i "\"build\":\"${BUILD}\"")
+RELEASE=$(wget --header "X-Plex-Token:"${TOKEN}"" "${URL_DOWNLOAD}" -O - 2>/dev/null | grep -ioe '"label"[^}]*' | grep -i "\"distro\":\"${DISTRO}\"" | grep -m1 -i "\"build\":\"${BUILD}\"")
 DOWNLOAD=$(echo ${RELEASE} | grep -m1 -ioe 'https://[^\"]*')
 CHECKSUM=$(echo ${RELEASE} | grep -ioe '\"checksum\"\:\"[^\"]*' | sed 's/\"checksum\"\:\"//')
 
@@ -646,7 +538,7 @@ fi
 
 if [ "${SKIP_DOWNLOAD}" = "no" ]; then
 	info "Downloading release \"${FILENAME}\""
-	wget ${WGETOPTIONS} -o "${FILE_WGETLOG}" --load-cookies "${FILE_KAKA}" --save-cookies "${FILE_KAKA}" --keep-session-cookies "${DOWNLOAD}" -O "${DOWNLOADDIR}/${FILENAME}" 2>&1
+	wget ${WGETOPTIONS} -o "${FILE_WGETLOG}" "${DOWNLOAD}" -O "${DOWNLOADDIR}/${FILENAME}" 2>&1
 	CODE=$?
 
 	if [ ${CODE} -ne 0 ]; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -476,7 +476,7 @@ if [ "${SKIP_DOWNLOAD}" = "no" ]; then
 	info "File downloaded"
 fi
 
-if sha1sum --status -c "${FILE_SHA}"; then
+if ! sha1sum --status -c "${FILE_SHA}"; then
 	error "Downloaded file corrupt. Try again."
 	exit 4
 fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -410,7 +410,7 @@ if [ "${CHECKUPDATE}" = "yes" -a "${AUTOUPDATE}" = "no" ]; then
 fi
 
 if [ "${PUBLIC}" = "no" -a -z "$TOKEN" ]; then
-	TO_SOURCE="$(dirname "$0")/extras/get-web-token"
+	TO_SOURCE="$(dirname "$0")/extras/get-plex-token"
 	[ -f "$TO_SOURCE" ] && source $TO_SOURCE
 	if ! getPlexToken; then
 		error "Unable to get Plex token, falling back to public release"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -395,6 +395,9 @@ if [ -z "${DOWNLOAD}" ]; then
 		error "Please try https://plex.tv and confirm it works there before reporting this issue"
 	fi
 	exit 3
+elif [ -z "${CHECKSUM}" ]; then
+	error "Unable to retrieve a checksum for the download. Please try https://plex.tv/downloads before reporting this issue."
+	exit 3
 fi
 
 FILENAME="$(basename 2>/dev/null ${DOWNLOAD})"


### PR DESCRIPTION
This is a bit of a massive change, but I think it's worth it for both security and future simplicity. The goal here is to only store a token in plexupdate.conf, not email/pass as we've historically been doing.

To implement this, I've extracted ALL of the token-handling code out of plexupdate.sh and into extras/get-plex-token. This gets sourced by plexupdate.sh if it needs a token and can't get it, otherwise it just sits there.

Since it's been abstracted out, there are now a couple of extra cool things we can do here. Using the exact same code, installer.sh can get your Plex token and write it to plexupdate.conf for you. Or, if you'd prefer to do stuff manually, you can manually execute extras/get-plex-token and it'll print your token for you so you can manually add it into plexupdate.conf if you'd like.

The biggest thing that I tried to make sure of was that, as long as you have a properly configured plexupdate.conf, you could continue to run plexupdate.sh as a completely standalone script without requiring anything else out of the repo.