### PR TITLE
Remove deprecated source from plexupdate.sh

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -335,6 +335,11 @@ if [ "${CHECKUPDATE}" = "yes" -a "${AUTOUPDATE}" = "no" ]; then
 fi
 
 if [ "${PUBLIC}" = "no" -a -z "$TOKEN" ]; then
+	declare -f getPlexToken > /dev/null
+	if [ $? -ne 0 ]; then
+		error "getPlexToken() function missing, check that it its sourced correctly"
+		exit 3
+	fi
 	if ! getPlexToken; then
 		error "Unable to get Plex token, falling back to public release"
 		PUBLIC="yes"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -335,8 +335,6 @@ if [ "${CHECKUPDATE}" = "yes" -a "${AUTOUPDATE}" = "no" ]; then
 fi
 
 if [ "${PUBLIC}" = "no" -a -z "$TOKEN" ]; then
-	TO_SOURCE="$(dirname "$0")/extras/get-plex-token"
-	[ -f "$TO_SOURCE" ] && source $TO_SOURCE
 	if ! getPlexToken; then
 		error "Unable to get Plex token, falling back to public release"
 		PUBLIC="yes"


### PR DESCRIPTION
Noticed this while debugging something else. `getPlexToken()` got moved to `plexupdate-core` rather than being separate in extras