### PR TITLE
Check if server activity call requires a token before asking for one

### DIFF
--- a/plexupdate-core
+++ b/plexupdate-core
@@ -178,8 +178,17 @@ getLocalSHA() {
 
 # RNNG
 running() {
-	local DATA="$(wget --no-check-certificate -q -O - https://$1:$3/status/sessions?X-Plex-Token=$2)"
+	# If a server is unclaimed, it probably doesn't have TLS enabled either
+	local DATA="$(wget -q -O - http://$1:$2/status/sessions)"
 	local RET=$?
+
+	if [ ${RET} -eq 6 ]; then
+		# Server may be claimed, in which case we should use TLS and pass a token
+		getPlexToken
+		DATA="$(wget --no-check-certificate -q -O - https://$1:$2/status/sessions?X-Plex-Token=$TOKEN)"
+		RET=$?
+	fi
+
 	if [ ${RET} -eq 0 ]; then
 		if [ -z "${DATA}" ]; then
 			# Odd, but usually means noone is watching

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -334,16 +334,9 @@ if [ "${CHECKUPDATE}" = "yes" -a "${AUTOUPDATE}" = "no" ]; then
 	popd > /dev/null
 fi
 
-if [ "${PUBLIC}" = "no" -o -n "${PLEXSERVER}" ] && ! getPlexToken; then
-	if [ "${PUBLIC}" = "no" ]; then
-		error "Unable to get Plex token, falling back to public release"
-		PUBLIC="yes"
-	fi
-
-	if [ -n "${PLEXSERVER}" ]; then
-		error "Unable to get Plex token, server activity check will be skipped"
-		PLEXSERVER=
-	fi
+if [ "${PUBLIC}" = "no" ] && ! getPlexToken; then
+	error "Unable to get Plex token, falling back to public release"
+	PUBLIC="yes"
 fi
 
 if [ "$PUBLIC" != "no" ]; then
@@ -491,7 +484,7 @@ fi
 
 if [ -n "${PLEXSERVER}" -a "${AUTOINSTALL}" = "yes" ]; then
 	# Check if server is in-use before continuing (thanks @AltonV, @hakong and @sufr3ak)...
-	if running "${PLEXSERVER}" "${TOKEN}" "${PLEXPORT}"; then
+	if running "${PLEXSERVER}" "${PLEXPORT}"; then
 		error "Server ${PLEXSERVER} is currently being used by one or more users, skipping installation. Please run again later"
 		exit 6
 	fi


### PR DESCRIPTION
I tried a few different approaches here, but I think this is the simplest. It's nearly impossible to enable TLS with an unclaimed server, so we start by just doing a plain check over HTTP. Claimed servers now actually **require** that TLS be enabled in order to enable remote access, so we just assume that claimed servers will have TLS enabled. (It's **possible** that you would claim a server, disable remote access, and disable TLS, but **extremely** unlikey.)