### PR TITLE
Split local variable declaration from assignment

### DIFF
--- a/plexupdate-core
+++ b/plexupdate-core
@@ -179,7 +179,8 @@ getLocalSHA() {
 # RNNG
 running() {
 	# If a server is unclaimed, it probably doesn't have TLS enabled either
-	local DATA="$(wget -q -O - http://$1:$2/status/sessions)"
+	local DATA
+	DATA="$(wget -q -O - http://$1:$2/status/sessions)"
 	local RET=$?
 
 	if [ ${RET} -eq 6 ]; then


### PR DESCRIPTION
This allows the return code to be correctly set.  Previously, RET was always being set to 0... the result of assigning the local variable.