### PR TITLE
[WIP] Improve version handling to prevent inadvertent downgrades

### DIFF
--- a/plexupdate-core
+++ b/plexupdate-core
@@ -240,6 +240,14 @@ getPlexVersion() {
 	fi
 }
 
+verboseOutput() {
+	if [ "$VERBOSE" = "yes" ]; then
+		for i in $@; do
+			info "$i=${!i}"
+		done
+	fi
+}
+
 # Shared functions
 
 # SHARED

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -209,6 +209,37 @@ verifyToken() {
 	wget -qO /dev/null "https://plex.tv/api/resources?X-Plex-Token=${TOKEN}"
 }
 
+isNewerVersion() {
+	# Returns true ONLY if 1 > 2.
+	[ -z "$1" ] && return 1
+	[ -z "$2" ] && return
+	[ "$1" = "$2" ] && return 1
+	if hash dpkg 2>/dev/null; then
+		dpkg --compare-versions "$1" gt "$2"
+	elif sort -V --version &>/dev/null; then
+		[ "$(printf "$1\n$2" | sort -Vr | head -n1)" = "$1" ]
+	else
+		# sort has had -V since at least 2009, so nobody should ever see this
+		warn "Unable to compare version numbers, assuming '$1' is newer."
+	fi
+}
+
+getPlexVersion() {
+	if [ "${REDHAT}" != "yes" ]; then
+		dpkg-query --showformat='${Version}' --show plexmediaserver 2>/dev/null
+	elif hash rpm 2>/dev/null; then
+		local rpmtemp
+		if rpmtemp=$(rpm -q plexmediaserver); then
+			cut -f2 -d_ <<< "$rpmtemp"
+		else
+			return 1
+		fi
+	else
+		error "Unknown OS, exiting."
+		exit 1
+	fi
+}
+
 # Shared functions
 
 # SHARED

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -224,13 +224,21 @@ isNewerVersion() {
 	fi
 }
 
+parseVersion() {
+	if [ "${REDHAT}" = "yes" ]; then
+		cut -f2- -d- <<< "$1" | cut -f1-4 -d.
+	else
+		cut -f2 -d_ <<< "$1"
+	fi
+}
+
 getPlexVersion() {
 	if [ "${REDHAT}" != "yes" ]; then
 		dpkg-query --showformat='${Version}' --show plexmediaserver 2>/dev/null
 	elif hash rpm 2>/dev/null; then
 		local rpmtemp
 		if rpmtemp=$(rpm -q plexmediaserver); then
-			cut -f2 -d_ <<< "$rpmtemp"
+			parseVersion "$rpmtemp"
 		else
 			return 1
 		fi

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -198,6 +198,7 @@ running() {
 		# Get a total count of active media (MediaContainer size), then deduct one for every paused stream.
 		# If all streams are paused, we consider the server to not be active.
 		local mediacount="$(awk -F'"' '/<MediaContainer size="[0-9]+">/ {count+=$2}; /<Player[^>]* state="paused"/ {count--}; END {print count}' <<< "${DATA}")"
+		[ "$VERBOSE" = "yes" ] && printf 'Activity check reports a count of %b, based on return data of:\n%s\n\n' "${DATA}" >&2
 		[ $mediacount -gt 0 ] && return 0
 	fi
 

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -198,7 +198,7 @@ running() {
 		# Get a total count of active media (MediaContainer size), then deduct one for every paused stream.
 		# If all streams are paused, we consider the server to not be active.
 		local mediacount="$(awk -F'"' '/<MediaContainer size="[0-9]+">/ {count+=$2}; /<Player[^>]* state="paused"/ {count--}; END {print count}' <<< "${DATA}")"
-		[ "$VERBOSE" = "yes" ] && printf 'Activity check reports a count of %b, based on return data of:\n%s\n\n' "${DATA}" >&2
+		[ "$VERBOSE" = "yes" ] && printf 'Activity check reports a count of %i, based on return data of:\n%s\n\n' "${mediacount}" "${DATA}" >&2
 		[ $mediacount -gt 0 ] && return 0
 	fi
 

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -431,7 +431,7 @@ if [ "${REDHAT}" = "yes" -a "${AUTOINSTALL}" = "yes" -a "${AUTOSTART}" = "no" ];
 fi
 
 if [ "${CHECKONLY}" = "yes" ]; then
-	if [ -n "${INSTALLED_VERSION}" ] && isNewerVersion "$FILE_VERSION" "$INSTALLED_VERSION" then
+	if [ -n "${INSTALLED_VERSION}" ] && isNewerVersion "$FILE_VERSION" "$INSTALLED_VERSION"; then
 		info "Your OS reports Plex $INSTALLED_VERSION installed, newer version is available (${FILE_VERSION})"
 		exit 7
 	elif [ -n "${INSTALLED_VERSION}" ]; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -228,8 +228,12 @@ if [ "${AUTOUPDATE}" = "yes" ]; then
 	elif ! git diff --quiet; then
 		warn "You have made changes to the plexupdate files, cannot auto update"
 	else
+		BRANCHNAME="${BRANCHNAME:-master}"
+		if [ "${BRANCHNAME}" != "$(git symbolic-ref -q --short HEAD)" ]; then
+			git checkout "${BRANCHNAME}"
+		fi
 		# Force FETCH_HEAD to point to the correct branch (for older versions of git which don't default to current branch)
-		if git fetch origin ${BRANCHNAME:-master} --quiet && ! git diff --quiet FETCH_HEAD; then
+		if git fetch origin ${BRANCHNAME} --quiet && ! git diff --quiet FETCH_HEAD; then
 			info "Auto-updating..."
 
 			# Use an associative array to store permissions. If you're running bash < 4, the declare will fail and we'll

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -228,8 +228,9 @@ if [ "${AUTOUPDATE}" = "yes" ]; then
 	elif ! git diff --quiet; then
 		warn "You have made changes to the plexupdate files, cannot auto update"
 	else
-		BRANCHNAME="${BRANCHNAME:-master}"
-		if [ "${BRANCHNAME}" != "$(git symbolic-ref -q --short HEAD)" ]; then
+		if [ -z "${BRANCHNAME}" ]; then
+			BRANCHNAME="$(git symbolic-ref -q --short HEAD)"
+		elif [ "${BRANCHNAME}" != "$(git symbolic-ref -q --short HEAD)" ]; then
 			git checkout "${BRANCHNAME}"
 		fi
 		# Force FETCH_HEAD to point to the correct branch (for older versions of git which don't default to current branch)

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -385,11 +385,7 @@ RELEASE=$(grep -ioe '"label"[^}]*' <<<"${wgetresults}" | grep -i "\"distro\":\"$
 DOWNLOAD=$(echo ${RELEASE} | grep -m1 -ioe 'https://[^\"]*')
 CHECKSUM=$(echo ${RELEASE} | grep -ioe '\"checksum\"\:\"[^\"]*' | sed 's/\"checksum\"\:\"//')
 
-if [ "$VERBOSE" = "yes" ]; then
-	for i in RELEASE DOWNLOAD CHECKSUM; do
-		info "$i=${!i}"
-	done
-fi
+verboseOutput RELEASE DOWNLOAD CHECKSUM
 
 if [ -z "${DOWNLOAD}" ]; then
 	if [ "$DISTRO" = "ubuntu" -a "$BUILD" = "linux-ubuntu-armv7l" ]; then
@@ -425,6 +421,7 @@ SKIP_DOWNLOAD="no"
 
 INSTALLED_VERSION="$(getPlexVersion)" || warn "Unable to detect installed version, first time?"
 FILE_VERSION="$(cut -f2 -d_ <<< "${FILENAME}")"
+verboseOutput INSTALLED_VERSION FILE_VERSION
 
 if [ "${REDHAT}" = "yes" -a "${AUTOINSTALL}" = "yes" -a "${AUTOSTART}" = "no" ]; then
 	warn "Your distribution may require the use of the AUTOSTART [-s] option for the service to start after the upgrade completes."

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -423,32 +423,26 @@ fi
 # By default, try downloading
 SKIP_DOWNLOAD="no"
 
-# Installed version detection
-if [ "${REDHAT}" != "yes" ]; then
-	INSTALLED_VERSION=$(dpkg-query -s plexmediaserver 2>/dev/null | grep -Po 'Version: \K.*')
-else
-	if [ "${AUTOINSTALL}" = "yes" -a "${AUTOSTART}" = "no" ]; then
-		warn "Your distribution may require the use of the AUTOSTART [-s] option for the service to start after the upgrade completes."
-	fi
-	INSTALLED_VERSION=$(rpm -qv plexmediaserver 2>/dev/null)
+INSTALLED_VERSION="$(getPlexVersion)" || warn "Unable to detect installed version, first time?"
+FILE_VERSION="$(cut -f2 -d_ <<< "${FILENAME}")"
+
+if [ "${REDHAT}" = "yes" -a "${AUTOINSTALL}" = "yes" -a "${AUTOSTART}" = "no" ]; then
+	warn "Your distribution may require the use of the AUTOSTART [-s] option for the service to start after the upgrade completes."
 fi
 
 if [ "${CHECKONLY}" = "yes" ]; then
-	if [ -z "${INSTALLED_VERSION}" ]; then
-		warn "Unable to detect installed version, first time?"
-	elif [[ $FILENAME != *$INSTALLED_VERSION* ]]; then
-		AVAIL="$(echo "${FILENAME}" | sed -nr 's/^[^0-9]+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\-[^_]+).*/\1/pg')"
-		info "Your OS reports Plex $INSTALLED_VERSION installed, newer version is available (${AVAIL})"
+	if [ -n "${INSTALLED_VERSION}" ] && isNewerVersion "$FILE_VERSION" "$INSTALLED_VERSION" then
+		info "Your OS reports Plex $INSTALLED_VERSION installed, newer version is available (${FILE_VERSION})"
 		exit 7
-	else
+	elif [ -n "${INSTALLED_VERSION}" ]; then
 		info "You are running the latest version of Plex (${INSTALLED_VERSION})"
 	fi
 	exit 0
 fi
 
-if [[ $FILENAME == *$INSTALLED_VERSION* ]] && [ "${FORCE}" != "yes" ] && [ ! -z "${INSTALLED_VERSION}" ]; then
-	info "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
-	exit 0
+if ! isNewerVersion "$FILE_VERSION" "$INSTALLED_VERSION" && [ "${FORCE}" != "yes" ]; then
+		info "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
+		exit 0
 fi
 
 if [ -f "${DOWNLOADDIR}/${FILENAME}" ]; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -420,7 +420,7 @@ fi
 SKIP_DOWNLOAD="no"
 
 INSTALLED_VERSION="$(getPlexVersion)" || warn "Unable to detect installed version, first time?"
-FILE_VERSION="$(cut -f2 -d_ <<< "${FILENAME}")"
+FILE_VERSION="$(parseVersion "${FILENAME}")"
 verboseOutput INSTALLED_VERSION FILE_VERSION
 
 if [ "${REDHAT}" = "yes" -a "${AUTOINSTALL}" = "yes" -a "${AUTOSTART}" = "no" ]; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -443,8 +443,8 @@ if [ "${CHECKONLY}" = "yes" ]; then
 fi
 
 if ! isNewerVersion "$FILE_VERSION" "$INSTALLED_VERSION" && [ "${FORCE}" != "yes" ]; then
-		info "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
-		exit 0
+	info "Your OS reports the latest version of Plex ($INSTALLED_VERSION) is already installed. Use -f to force download."
+	exit 0
 fi
 
 if [ -f "${DOWNLOADDIR}/${FILENAME}" ]; then


### PR DESCRIPTION
Added support for actually comparing version numbers rather than just seeing if the new filename is different from the existing one (and fixed a couple of rpm-related bugs that I didn't even know were there). This should help address a possible side-effect of the problem described in #224 -- if you manually ran plexupdate.sh -p while this was happening, but then later went back to PlexPass, you'd get downgraded. That should no longer happen at least.

This should also make it slightly easier to implement support for checking both public and PlexPass at some point in the future and just picking whichever one is newer (just in case this ends up being a recurring problem).