### PR TITLE
Fix quoting in running(). Fixes #227

### DIFF
--- a/plexupdate-core
+++ b/plexupdate-core
@@ -197,7 +197,7 @@ running() {
 	if [ ${RET} -eq 0 ]; then
 		# Get a total count of active media (MediaContainer size), then deduct one for every paused stream.
 		# If all streams are paused, we consider the server to not be active.
-		local mediacount="$(awk -F'"' '/<MediaContainer size="[0-9]+">/ {count+=$2}; /<Player[^>]* state="paused"/ {count--}; END {print count}' <<< ${DATA})"
+		local mediacount="$(awk -F'"' '/<MediaContainer size="[0-9]+">/ {count+=$2}; /<Player[^>]* state="paused"/ {count--}; END {print count}' <<< "${DATA}")"
 		[ $mediacount -gt 0 ] && return 0
 	fi
 


### PR DESCRIPTION
Turns out that bash 4.4 [fixed a bug](http://tiswww.case.edu/php/chet/bash/CHANGES) which allowed this to work (which is what I was testing on), but anyone using an earlier version of bash would get this error.

> z.  Bash no longer splits the expansion of here-strings, as the documentation
>     has always said.