### PR TITLE
Introduce new option: KEEPREVERTED.

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -52,6 +52,7 @@ AUTOINSTALL=no
 AUTODELETE=no
 AUTOUPDATE=no
 AUTOSTART=no
+KEEPREVERTED=no
 ARCH=$(uname -m)
 SHOWPROGRESS=no
 WGETOPTIONS=""	# extra options for wget. Used for progress bar.
@@ -81,6 +82,8 @@ usage() {
 	echo "    -s Auto start (needed for some distros)"
 	echo "    -u Auto update plexupdate.sh before running it (default with installer)"
 	echo "    -U Do not autoupdate plexupdate.sh"
+	echo "    -k Keep reverted version if newer version has already been downloaded. (overriden by -f)"
+	echo "    -K Update even when latest package has already been downloaded but is not installed. (default with installer)"
 	echo "    -v Show additional debug information"
 	echo ""
 	echo "    Long Argument Options:"
@@ -160,6 +163,8 @@ do
 		(-u) AUTOUPDATE=yes;;
 		(-U) AUTOUPDATE=no;;
 		(-v) VERBOSE=yes;;
+		(-k) KEEPREVERTED=yes;;
+		(-K) KEEPREVERTED=no;;
 
 		(--config) shift;; #gobble up the paramater and silently continue parsing
 		(--dldir) shift; DOWNLOADDIR=$(trimQuotes ${1});;
@@ -471,6 +476,10 @@ if [ "${SKIP_DOWNLOAD}" = "no" ]; then
 		exit ${CODE}
 	fi
 	info "File downloaded"
+elif [ "${KEEPREVERTED}" = "yes" -a "${FORCE}" != "yes" ]; then
+	# We are skipping the download so the file already exists and is a valid download, but we aren't running that version.
+	info "Release \"${FILENAME}\" has already been downloaded, but is not installed.  KEEPREVERTED has been set, so we will not install the new version.  Use -K to turn KEEPREVERTED off or -f to force."
+	exit 0
 fi
 
 if ! sha1sum --status -c "${FILE_SHA}"; then

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -96,6 +96,7 @@ usage() {
 	echo "    --port <Plex server port> Port for Plex Server. Used with --server"
 	echo "    --server <Plex server address> Address of Plex Server"
 	echo "    --token Manually specify the token to use to download Plex Pass releases"
+	echo "    --run-after Program to run after successful install."
 	echo ""
 	exit 0
 }
@@ -174,6 +175,7 @@ do
 		(--server) shift; PLEXSERVER=$(trimQuotes ${1});;
 		(--port) shift; PLEXPORT=$(trimQuotes ${1});;
 		(--token) shift; TOKEN=$(trimQuotes ${1});;
+		(--run-after) shift; RUNAFTER=$(trimQuotes ${1});;
 		(--help) usage;;
 
 		(--notify-success) NOTIFY=yes;;
@@ -500,8 +502,14 @@ if [ "${AUTOINSTALL}" = "yes" ]; then
 	RET=$?
 	if [ ${RET} -ne 0 ]; then
 		# Clarify why this failed, so user won't be left in the dark
-		error "Failed to install update. Command '${DISTRO_INSTALL} "${DOWNLOADDIR}/${FILENAME}"' returned error code ${RET}"
+		error "Failed to install update. Command '${DISTRO_INSTALL} \"${DOWNLOADDIR}/${FILENAME}\"' returned error code ${RET}"
 		exit ${RET}
+	fi
+
+	if [ ! -z "${RUNAFTER}" ]; then
+		# RUNAFTER command has been set.  Pass version number as a parameter.
+		verboseOutput "Successfully installed update.  Running '${RUNAFTER} \"${FILE_VERSION}\"'"
+		${RUNAFTER} "${FILE_VERSION}"
 	fi
 fi
 


### PR DESCRIPTION
New option KEEPREVERTED with switches -k/-K to enable and disable
(default).

Feature will stop prevent updating if the latest version has been
downloaded previously (and the checksum passes) but is not the currently
installed version.  This will allow one to revert by re-installing the
previous version (in the case of a regression in plex) and not have it
clobbered the next time plexupdate runs; however, when a new version is
released, it should continue to update from that version and beyond.