### PR TITLE
patch for Raspberry Pi 4 reporting as armv7l

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -53,6 +53,8 @@ AUTODELETE=no
 AUTOUPDATE=no
 AUTOSTART=no
 ARCH=$(uname -m)
+# patch for Raspberry Pi 4 reporting as armv7l, whereas Plex only offers armv7hf_neon
+cat /proc/cpuinfo | grep -q "Raspberry Pi 4" && ARCH=armv7hf_neon
 BUILD="linux-$ARCH"
 SHOWPROGRESS=no
 WGETOPTIONS=""	# extra options for wget. Used for progress bar.


### PR DESCRIPTION
Raspberrypi 4 reports as armv7l, whereas Plex only offers a armv7hf_neon architecture for the build. This armv7hf_neon package will run fine on a Pi 4.
This patch also fixes #253 