### PR TITLE
Fix Plex token regex matching

### DIFF
--- a/plexupdate-core
+++ b/plexupdate-core
@@ -78,9 +78,9 @@ getPlexServerToken() {
 		if [ ! -z "${I}" -a -f "${I}${PREFFILE}" ]; then
 			# When running installer.sh directly from wget, $0 will return bash
 			if [ "$(basename $0)" = "installer.sh" -o "$(basename $0)" = "bash" ]; then
-				TOKEN=$(sudo sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
+				TOKEN=$(sudo sed -n 's/.*PlexOnlineToken="\([[:alnum:]_-]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
 			else
-				TOKEN=$(sed -n 's/.*PlexOnlineToken="\([[:alnum:]]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
+				TOKEN=$(sed -n 's/.*PlexOnlineToken="\([[:alnum:]_-]*\).*".*/\1/p' "${I}${PREFFILE}" 2>/dev/null)
 			fi
 		fi
 	done


### PR DESCRIPTION
The current regex expression for matching the Plex token within Preferences.xml is restricted to alphanumeric characters only.  At some point, this must have changed, because my current token contains dashes, and I have seen web tokens contain underscores.  These have been added to the expression to correctly match the entire token.