### PR TITLE
Expand Raspberry Pi support to 3/4

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -53,8 +53,8 @@ AUTODELETE=no
 AUTOUPDATE=no
 AUTOSTART=no
 ARCH=$(uname -m)
-# patch for Raspberry Pi 4 reporting as armv7l, whereas Plex only offers armv7hf_neon
-cat /proc/cpuinfo | grep -q "Raspberry Pi 4" && ARCH=armv7hf_neon
+# patch for Raspberry Pi reporting as armv7l, whereas Plex only offers armv7hf_neon
+[ "$ARCH" = "armv7l" ] && ARCH="armv7hf_neon"
 BUILD="linux-$ARCH"
 SHOWPROGRESS=no
 WGETOPTIONS=""	# extra options for wget. Used for progress bar.

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -233,12 +233,14 @@ if [ "${AUTOUPDATE}" = "yes" ]; then
 	else
 		if [ -z "${BRANCHNAME}" ]; then
 			BRANCHNAME="$(git symbolic-ref -q --short HEAD)"
-		elif [ "${BRANCHNAME}" != "$(git symbolic-ref -q --short HEAD)" ]; then
-			git checkout "${BRANCHNAME}"
 		fi
 		# Force FETCH_HEAD to point to the correct branch (for older versions of git which don't default to current branch)
 		if git fetch origin ${BRANCHNAME} --quiet && ! git diff --quiet FETCH_HEAD; then
 			info "Auto-updating..."
+
+			if [ "${BRANCHNAME}" != "$(git symbolic-ref -q --short HEAD)" ]; then
+				git checkout "${BRANCHNAME}"
+			fi
 
 			# Use an associative array to store permissions. If you're running bash < 4, the declare will fail and we'll
 			# just run in "dumb" mode without trying to restore permissions


### PR DESCRIPTION
The previous changes for the rpi4 seem to work just fine for the 3 as well, so this will allow any armv7l devices to use the Plex armv7hf build.

Closes #273 