### PR TITLE
Test run should run with sudo if installed as root

### DIFF
--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -358,7 +358,7 @@ if yesno; then
 	if wget --show-progress -V &> /dev/null; then
 		PROGRESS_OPT="-P"
 	fi
-	if [ "$AUTOINSTALL" == "yes" ] || [ "$CRON" == "yes" ]; then
+	if [ "$AUTOINSTALL" == "yes" -o "$CRON" == "yes" ]; then
 		sudo -E "$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"
 	else
 		"$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -354,7 +354,7 @@ if yesno; then
 	if wget --show-progress -V &> /dev/null; then
 		PROGRESS_OPT="-P"
 	fi
-	if [ "$AUTOINSTALL" == "yes" ]; then
+	if [ "$AUTOINSTALL" == "yes" ] || [ -f "$CONFIGCRON" ]; then
 		sudo -E "$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"
 	else
 		"$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -245,6 +245,7 @@ configure_cron() {
 	echo
 	echo -n "Would you like to set up automatic daily updates for Plex? "
 	if yesno $CRON; then
+		CRON=yes
 		if [ $(sudo find -L "${FULL_PATH}" -perm /002 -or -not -uid 0 -or -not -gid 0 | wc -l) -ne 0 ]; then
 			echo
 			echo "WARNING: For security reasons, plexupdate needs to be installed as root in order to run automatically. In order to finish setting up automatic updates, we will change the ownership of '${FULL_PATH}' to root:root."

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -236,7 +236,11 @@ configure_cron() {
 		return 1
 	fi
 
-	[ -f "$CONFIGCRON" ] && source "$CONFIGCRON"
+	if [ -f "$CONFIGCRON" ]; then
+		#this is redundant since null is evaluated as yes anyway, but including for readability
+		CRON=yes
+		source "$CONFIGCRON"
+	fi
 
 	echo
 	echo -n "Would you like to set up automatic daily updates for Plex? "
@@ -354,7 +358,7 @@ if yesno; then
 	if wget --show-progress -V &> /dev/null; then
 		PROGRESS_OPT="-P"
 	fi
-	if [ "$AUTOINSTALL" == "yes" ] || [ -f "$CONFIGCRON" ]; then
+	if [ "$AUTOINSTALL" == "yes" ] || [ "$CRON" == "yes" ]; then
 		sudo -E "$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"
 	else
 		"$FULL_PATH/plexupdate.sh" $PROGRESS_OPT --config "$CONFIGFILE"


### PR DESCRIPTION
This was just an oversight in the original logic for doing a test run. If a user selects to disable autoinstall, the test run gets executed as the normal user, even if cron was selected which chowned everything over to root.