### PR TITLE
naming scheme for Raspberry Pi package changed again. Now it's armv7n…

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -54,7 +54,7 @@ AUTOUPDATE=no
 AUTOSTART=no
 ARCH=$(uname -m)
 # patch for Raspberry Pi reporting as armv7l, whereas Plex only offers armv7hf_neon
-[ "$ARCH" = "armv7l" ] && ARCH="armv7hf_neon"
+[ "$ARCH" = "armv7l" ] && ARCH="armv7neon"
 BUILD="linux-$ARCH"
 SHOWPROGRESS=no
 WGETOPTIONS=""	# extra options for wget. Used for progress bar.

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -53,7 +53,7 @@ AUTODELETE=no
 AUTOUPDATE=no
 AUTOSTART=no
 ARCH=$(uname -m)
-# patch for Raspberry Pi reporting as armv7l, whereas Plex only offers armv7hf_neon
+# patch for Raspberry Pi reporting as armv7l, whereas Plex only offers armv7neon
 [ "$ARCH" = "armv7l" ] && ARCH="armv7neon"
 BUILD="linux-$ARCH"
 SHOWPROGRESS=no


### PR DESCRIPTION
…eon instead of armv7hf_neon