### PR TITLE
Support for Synology [DSM 7]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ If you'd ever like to change your configuration, just re-run the installer from 
 
 If you have any trouble with the installer, or would just prefer to set plexupdate up manually, [read the guide](https://github.com/mrworf/plexupdate/wiki/Manually-installing-plexupdate).
 
+## Synology Installation
+
+Before installing on a Synology NAS, you will need to follow the instructions in the Plex support article [How to add Plex’s package signing public key to Synology NAS Package Center](https://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/).
+
+Then you can follow the regular installation instructions as normal.
+
 # Advanced options
 
 There are a few additional options for the more enterprising user. Setting any of these to `yes` will enable the function.

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -42,6 +42,9 @@ check_distro() {
 	elif hash apt-get 2>/dev/null; then
 		DISTRO="debian"
 		DISTRO_INSTALL="apt-get install"
+	elif [ -f /etc/synoinfo.conf ]; then
+	        DISTRO="synology"
+	        DISTRO_INSTALL="synopkg install"
 	else
 		DISTRO="unknown"
 	fi

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -45,10 +45,13 @@ check_distro() {
 		DISTRO_INSTALL="apt-get install"
 	elif [ -f /etc/synoinfo.conf ]; then
 		DISTRO="synology"
-		if grep -q "major=\"7\"" /etc/VERSION; then
-			DISTRO="synology-dsm7"
-		fi
 		DISTRO_INSTALL="synopkg install"
+		if grep -q "major=\"7\"" /etc/VERSION; then
+			DISTRO="synology-dsm72"
+			if grep -q "minor=\"[01]\"" /etc/VERSION; then
+				DISTRO="synology-dsm7"
+			fi
+		fi
 	else
 		DISTRO="unknown"
 	fi
@@ -189,7 +192,7 @@ configure_plexupdate() {
 		AUTODELETE=yes
 		
 		[ -z "$DISTRO" ] && check_distro
-		if [ "$DISTRO" == "redhat" -o "$DISTRO" == "synology" -o "$DISTRO" == "synology-dsm7" ]; then
+		if [ "$DISTRO" == "redhat" -o $(echo "${DISTRO}" | cut -c -8) = "synology" ]; then
 			AUTOSTART=yes
 		else
 			AUTOSTART=

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -44,8 +44,11 @@ check_distro() {
 		DISTRO="debian"
 		DISTRO_INSTALL="apt-get install"
 	elif [ -f /etc/synoinfo.conf ]; then
-	        DISTRO="synology"
-	        DISTRO_INSTALL="synopkg install"
+		DISTRO="synology"
+		if grep -q "major=\"7\"" /etc/VERSION; then
+			DISTRO="synology-dsm7"
+		fi
+		DISTRO_INSTALL="synopkg install"
 	else
 		DISTRO="unknown"
 	fi
@@ -186,7 +189,7 @@ configure_plexupdate() {
 		AUTODELETE=yes
 		
 		[ -z "$DISTRO" ] && check_distro
-		if [ "$DISTRO" == "redhat" -o "$DISTRO" == "synology" ]; then
+		if [ "$DISTRO" == "redhat" -o "$DISTRO" == "synology" -o "$DISTRO" == "synology-dsm7" ]; then
 			AUTOSTART=yes
 		else
 			AUTOSTART=

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -312,6 +312,7 @@ configure_cron() {
 
 save_cronjob() {
 	CONFIGTEMP=$(mktemp /tmp/plexupdate.XXX)
+	echo "$(grep "MAILTO=" /etc/crontab)" >> $CONFIGTEMP
 	echo "$(grep "PATH=" /etc/crontab)" >> $CONFIGTEMP
 	echo "#minute	hour	mday	month	wday	who	command" >> $CONFIGTEMP
 	echo "$1" >> $CONFIGTEMP

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -287,7 +287,7 @@ configure_cron() {
 		#changes go here
 		schedule=$(grep "cron.daily" crontab)
 		if [ -z "$schedule" ]; then
-    			schedule="0	4	*	*	*	"
+			schedule="0	4	*	*	*	"
 		else
 			schedule=${schedule%%root*}
 		fi
@@ -312,6 +312,7 @@ configure_cron() {
 
 save_cronjob() {
 	CONFIGTEMP=$(mktemp /tmp/plexupdate.XXX)
+	echo "$(grep "PATH=" /etc/crontab)" >> $CONFIGTEMP
 	echo "#minute	hour	mday	month	wday	who	command" >> $CONFIGTEMP
 	echo "$1" >> $CONFIGTEMP
 

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -184,9 +184,7 @@ configure_plexupdate() {
 		AUTOINSTALL=yes
 
 		[ -z "$DISTRO" ] && check_distro
-		if [ "$DISTRO" == "redhat" ]; then
-			AUTOSTART=yes
-		elif [ "$DISTRO" == "synology" ]; then
+		if [ "$DISTRO" == "redhat" -o "$DISTRO" == "synology" ]; then
 			AUTOSTART=yes
 		else
 			AUTOSTART=

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -316,17 +316,7 @@ save_cronjob() {
 	echo "#minute	hour	mday	month	wday	who	command" >> $CONFIGTEMP
 	echo "$1" >> $CONFIGTEMP
 
-	echo
-	echo -n "Writing cron job file '$2'... "
-
-	# most likely writing to /etc, so we need sudo
-	sudo tee "$2" > /dev/null < "$CONFIGTEMP"
-	sudo chmod 640 "$2"
-	# only root can modify the config, but the user can still read it
-	sudo chown 0:$(id -g) "$2"
-	rm "$CONFIGTEMP"
-
-	echo "done"
+	save_config_tmp "$CONFIGTEMP" "$2"
 }
 
 save_config() {
@@ -337,15 +327,19 @@ save_config() {
 		fi
 	done
 
+	save_config_tmp "$CONFIGTEMP" "$2"
+}
+
+save_config_tmp() {
 	echo
 	echo -n "Writing configuration file '$2'... "
 
 	# most likely writing to /etc, so we need sudo
-	sudo tee "$2" > /dev/null < "$CONFIGTEMP"
+	sudo tee "$2" > /dev/null < "$1"
 	sudo chmod 640 "$2"
 	# only root can modify the config, but the user can still read it
 	sudo chown 0:$(id -g) "$2"
-	rm "$CONFIGTEMP"
+	rm "$1"
 
 	echo "done"
 }

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -186,6 +186,8 @@ configure_plexupdate() {
 		[ -z "$DISTRO" ] && check_distro
 		if [ "$DISTRO" == "redhat" ]; then
 			AUTOSTART=yes
+		elif [ "$DISTRO" == "synology" ]; then
+			AUTOSTART=yes
 		else
 			AUTOSTART=
 		fi

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -284,7 +284,7 @@ configure_cron() {
 
 		echo
 		echo -n "Installing daily cron job... "
-		#changes go here
+		
 		schedule=$(grep "cron.daily" crontab)
 		if [ -z "$schedule" ]; then
 			schedule="0	4	*	*	*	"

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -182,7 +182,8 @@ configure_plexupdate() {
 
 	if yesno "$AUTOINSTALL"; then
 		AUTOINSTALL=yes
-
+		AUTODELETE=yes
+		
 		[ -z "$DISTRO" ] && check_distro
 		if [ "$DISTRO" == "redhat" -o "$DISTRO" == "synology" ]; then
 			AUTOSTART=yes

--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -291,7 +291,7 @@ configure_cron() {
 		else
 			schedule=${schedule%%root*}
 		fi
-		save_cronjob "${schedule}root	$(which sh)	${FULL_PATH}/extras/cronwrapper" "$CRONWRAPPER"
+		save_cronjob "$schedule" "$CRONWRAPPER"
 		echo "done"
 	elif [ -f "$CRONWRAPPER" -o -f "$CONFIGCRON" ]; then
 		echo
@@ -315,7 +315,7 @@ save_cronjob() {
 	echo "$(grep "MAILTO=" /etc/crontab)" >> $CONFIGTEMP
 	echo "$(grep "PATH=" /etc/crontab)" >> $CONFIGTEMP
 	echo "#minute	hour	mday	month	wday	who	command" >> $CONFIGTEMP
-	echo "$1" >> $CONFIGTEMP
+	echo "${1}root	$(which sh)	${FULL_PATH}/extras/cronwrapper" >> $CONFIGTEMP
 
 	save_config_tmp "$CONFIGTEMP" "$2"
 }

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -229,7 +229,7 @@ parseVersion() {
 	if [ "${REDHAT}" = "yes" ]; then
 		cut -f2- -d- <<< "$1" | cut -f1-4 -d.
 	elif [ "${DISTRO}" = "synology" ]; then
-		cut -f2 -d- <<< "$1"
+		cut -f2-3 -d- <<< "$1"
 	else
 		cut -f2 -d_ <<< "$1"
 	fi

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -228,13 +228,17 @@ isNewerVersion() {
 parseVersion() {
 	if [ "${REDHAT}" = "yes" ]; then
 		cut -f2- -d- <<< "$1" | cut -f1-4 -d.
+	elif [ "${DISTRO}" = "synology" ]; then
+		cut -f2 -d- <<< "$1"
 	else
 		cut -f2 -d_ <<< "$1"
 	fi
 }
 
 getPlexVersion() {
-	if [ "${REDHAT}" != "yes" ]; then
+	if [ "${DISTRO}" = "synology" ]; then
+		synopkg version "Plex Media Server" 2>/dev/null
+	elif [ "${REDHAT}" != "yes" ]; then
 		dpkg-query --showformat='${Version}' --show plexmediaserver 2>/dev/null
 	elif hash rpm 2>/dev/null; then
 		local rpmtemp

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -230,7 +230,7 @@ parseVersion() {
 		cut -f2- -d- <<< "$1" | cut -f1-4 -d.
 	elif [ "${DISTRO}" = "synology" ]; then
 		cut -f2-3 -d- <<< "$1"
-	elif [ "${DISTRO}" = "synology-dsm7" ]; then
+	elif [ $(echo "${DISTRO}" | cut -c -13) = "synology-dsm7" ]; then
 		cut -f2 -d- <<< "$1"
 	else
 		cut -f2 -d_ <<< "$1"
@@ -242,7 +242,7 @@ getPlexVersion() {
 		dpkg-query --showformat='${Version}' --show plexmediaserver 2>/dev/null
 	elif [ "${DISTRO}" = "synology" ]; then
 		synopkg version "Plex Media Server" 2>/dev/null
-	elif [ "${DISTRO}" = "synology-dsm7" ]; then
+	elif [ $(echo "${DISTRO}" | cut -c -13) = "synology-dsm7" ]; then
 		synopkg version "PlexMediaServer" 2>/dev/null | cut -f1 -d-
 	elif [ "${DISTRO}" = "redhat" ]; then
 		local rpmtemp

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -51,7 +51,7 @@ getPlexToken() {
 			fi
 		done
 		while true; do
-			read -e -p "PlexPass Password: " -i "$PASS" PASS
+			read -e -s -p "PlexPass Password: " -i "$PASS" PASS
 			if [ -z "$PASS" ]; then
 				info "Please provide a password"
 			else

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -228,8 +228,10 @@ isNewerVersion() {
 parseVersion() {
 	if [ "${DISTRO}" = "redhat" ]; then
 		cut -f2- -d- <<< "$1" | cut -f1-4 -d.
-	elif [ "${DISTRO}" = "synology" -o "${DISTRO}" = "synology-dsm7" ]; then
+	elif [ "${DISTRO}" = "synology" ]; then
 		cut -f2-3 -d- <<< "$1"
+	elif [ "${DISTRO}" = "synology-dsm7" ]; then
+		cut -f2 -d- <<< "$1"
 	else
 		cut -f2 -d_ <<< "$1"
 	fi
@@ -241,7 +243,7 @@ getPlexVersion() {
 	elif [ "${DISTRO}" = "synology" ]; then
 		synopkg version "Plex Media Server" 2>/dev/null
 	elif [ "${DISTRO}" = "synology-dsm7" ]; then
-		synopkg version "PlexMediaServer" 2>/dev/null
+		synopkg version "PlexMediaServer" 2>/dev/null | cut -f1 -d-
 	elif [ "${DISTRO}" = "redhat" ]; then
 		local rpmtemp
 		if rpmtemp=$(rpm -q plexmediaserver); then

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -228,7 +228,7 @@ isNewerVersion() {
 parseVersion() {
 	if [ "${DISTRO}" = "redhat" ]; then
 		cut -f2- -d- <<< "$1" | cut -f1-4 -d.
-	elif [ "${DISTRO}" = "synology" ]; then
+	elif [ "${DISTRO}" = "synology" -o "${DISTRO}" = "synology-dsm7" ]; then
 		cut -f2-3 -d- <<< "$1"
 	else
 		cut -f2 -d_ <<< "$1"
@@ -240,6 +240,8 @@ getPlexVersion() {
 		dpkg-query --showformat='${Version}' --show plexmediaserver 2>/dev/null
 	elif [ "${DISTRO}" = "synology" ]; then
 		synopkg version "Plex Media Server" 2>/dev/null
+	elif [ "${DISTRO}" = "synology-dsm7" ]; then
+		synopkg version "PlexMediaServer" 2>/dev/null
 	elif [ "${DISTRO}" = "redhat" ]; then
 		local rpmtemp
 		if rpmtemp=$(rpm -q plexmediaserver); then

--- a/plexupdate-core
+++ b/plexupdate-core
@@ -226,7 +226,7 @@ isNewerVersion() {
 }
 
 parseVersion() {
-	if [ "${REDHAT}" = "yes" ]; then
+	if [ "${DISTRO}" = "redhat" ]; then
 		cut -f2- -d- <<< "$1" | cut -f1-4 -d.
 	elif [ "${DISTRO}" = "synology" ]; then
 		cut -f2-3 -d- <<< "$1"
@@ -236,11 +236,11 @@ parseVersion() {
 }
 
 getPlexVersion() {
-	if [ "${DISTRO}" = "synology" ]; then
-		synopkg version "Plex Media Server" 2>/dev/null
-	elif [ "${REDHAT}" != "yes" ]; then
+	if [ "${DISTRO}" = "debian" ]; then
 		dpkg-query --showformat='${Version}' --show plexmediaserver 2>/dev/null
-	elif hash rpm 2>/dev/null; then
+	elif [ "${DISTRO}" = "synology" ]; then
+		synopkg version "Plex Media Server" 2>/dev/null
+	elif [ "${DISTRO}" = "redhat" ]; then
 		local rpmtemp
 		if rpmtemp=$(rpm -q plexmediaserver); then
 			parseVersion "$rpmtemp"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -314,7 +314,7 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 			DISTRO="synology"
 			if grep -q "major=\"7\"" /etc/VERSION; then
 				DISTRO="synology-dsm72"
-				if [ grep -q "minor=\"[01]\"" /etc/VERSION ]; then
+				if grep -q "minor=\"[01]\"" /etc/VERSION; then
 					DISTRO="synology-dsm7"
 	 			fi
 			fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -313,7 +313,10 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 		elif [ -f /etc/synoinfo.conf ]; then
 			DISTRO="synology"
 			if grep -q "major=\"7\"" /etc/VERSION; then
-				DISTRO="synology-dsm7"
+				DISTRO="synology-dsm72"
+				if [ grep -q "minor=\"[01]\"" /etc/VERSION ]; then
+					DISTRO="synology-dsm7"
+	 			fi
 			fi
 			DISTRO_INSTALL="synopkg install"
 		else

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -312,13 +312,13 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 			fi
 		elif [ -f /etc/synoinfo.conf ]; then
 			DISTRO="synology"
+			DISTRO_INSTALL="synopkg install"
 			if grep -q "major=\"7\"" /etc/VERSION; then
 				DISTRO="synology-dsm72"
 				if grep -q "minor=\"[01]\"" /etc/VERSION; then
 					DISTRO="synology-dsm7"
 	 			fi
 			fi
-			DISTRO_INSTALL="synopkg install"
 		else
 			DISTRO="debian"
 			DISTRO_INSTALL="${DEBIAN_INSTALL}"
@@ -504,8 +504,8 @@ if [ "${AUTOINSTALL}" = "yes" ]; then
 		# Clarify why this failed, so user won't be left in the dark
 		error "Failed to install update. Command '${DISTRO_INSTALL} "${DOWNLOADDIR}/${FILENAME}"' returned error code ${RET}"
 		if [ ${RET} -eq 1 ]; then
-			if [ "${DISTRO}" = "synology" || "${DISTRO}" = "synology-dsm7" ]; then
-				error "On Synology devices, you need to add Plex's public key to Package Center. If you have not done so, follow the instructions at https://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/"
+			if [ "${DISTRO}" = "synology" ]; then
+				error "On Synology DSM6 devices, you need to add Plex's public key to Package Center. If you have not done so, follow the instructions at https://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/"
 			fi
 		fi
 		exit ${RET}
@@ -522,13 +522,13 @@ if [ "${AUTODELETE}" = "yes" ]; then
 fi
 
 if [ "${AUTOSTART}" = "yes" ]; then
-	if [ "${DISTRO}" != "redhat" -a "${DISTRO}" != "synology" -a "${DISTRO}" != "synology-dsm7" ]; then
+	if [ "${DISTRO}" != "redhat" -a $(echo "${DISTRO}" | cut -c -8) != "synology"]; then
 		warn "The AUTOSTART [-s] option may not be needed on your distribution."
 	fi
 
 	if [ "${DISTRO}" = "synology" ]; then
 		synopkg start "Plex Media Server"
-	elif [ "${DISTRO}" = "synology-dsm7" ]; then
+	elif [ $(echo "${DISTRO}" | cut -c -13) = "synology-dsm7" ]; then
 		synopkg start "PlexMediaServer"
 	elif hash systemctl 2>/dev/null; then
 		systemctl start "$SYSTEMDUNIT"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -309,17 +309,7 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 			fi
 		elif [ -f /etc/synoinfo.conf ]; then
 			DISTRO="synology"
-			if [ "${PUBLIC}" = "yes" ]; then
-				if [ "${ARCH}" = "x86_64" ]; then
-					BUILD="linux-ubuntu-x86_64"
-				elif [ "${ARCH}" = "x86" ]; then
-					BUILD="linux-synology-i686"
-				elif [ "${ARCH}" = "armv7" ]; then
-					BUILD="linux-synology-armv7"
-				fi
-			else
-				BUILD="linux-${ARCH}"
-			fi
+			BUILD="linux-${ARCH}"
 			DISTRO_INSTALL="synopkg install"
 		else
 			REDHAT=no

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -308,14 +308,14 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 				DISTRO_INSTALL="${REDHAT_INSTALL}"
 			fi
 		elif [ -f /etc/synoinfo.conf ]; then
-		        DISTRO="synology"
-		        if [ "${PUBLIC}" = "yes" ]; then
-			        if [ "${ARCH}" = "x86_64" ]; then
-				    BUILD="linux-ubuntu-x86_64"
+			DISTRO="synology"
+			if [ "${PUBLIC}" = "yes" ]; then
+				if [ "${ARCH}" = "x86_64" ]; then
+					BUILD="linux-ubuntu-x86_64"
 				elif [ "${ARCH}" = "x86" ]; then
-				    BUILD="linux-synology-i686"
+					BUILD="linux-synology-i686"
 				elif [ "${ARCH}" = "armv7" ]; then
-				    BUILD="linux-synology-armv7"
+					BUILD="linux-synology-armv7"
 				fi
 			else
 				BUILD="linux-${ARCH}"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -494,7 +494,7 @@ if [ "${AUTOINSTALL}" = "yes" ]; then
 		# Clarify why this failed, so user won't be left in the dark
 		error "Failed to install update. Command '${DISTRO_INSTALL} "${DOWNLOADDIR}/${FILENAME}"' returned error code ${RET}"
 		if [ "${DISTRO}" = "synology" -a ${RET} -eq 1 ]; then
-			info "On Synology devices, you need to add Plex's public key to Package Center. If you have not done so, follow the instructions at \033[0;34mhttps://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/\033[0m"
+			echo -e "On Synology devices, you need to add Plex's public key to Package Center. If you have not done so, follow the instructions at \033[0;34mhttps://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/\033[0m"
 		fi
 		exit ${RET}
 	fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -300,7 +300,6 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 	if [ -z "${DISTRO}" ]; then
 		# Detect if we're running on redhat instead of ubuntu
 		if [ -f /etc/redhat-release ]; then
-			REDHAT=yes
 			DISTRO="redhat"
 			if ! hash dnf 2>/dev/null; then
 				DISTRO_INSTALL="${REDHAT_INSTALL/dnf/yum}"
@@ -311,7 +310,6 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 			DISTRO="synology"
 			DISTRO_INSTALL="synopkg install"
 		else
-			REDHAT=no
 			DISTRO="debian"
 			DISTRO_INSTALL="${DEBIAN_INSTALL}"
 		fi
@@ -427,7 +425,7 @@ INSTALLED_VERSION="$(getPlexVersion)" || warn "Unable to detect installed versio
 FILE_VERSION="$(parseVersion "${FILENAME}")"
 verboseOutput INSTALLED_VERSION FILE_VERSION
 
-if [ "${REDHAT}" = "yes" -a "${AUTOINSTALL}" = "yes" -a "${AUTOSTART}" = "no" ]; then
+if [ "${DISTRO}" = "redhat" -a "${AUTOINSTALL}" = "yes" -a "${AUTOSTART}" = "no" ]; then
 	warn "Your distribution may require the use of the AUTOSTART [-s] option for the service to start after the upgrade completes."
 fi
 
@@ -486,7 +484,7 @@ if [ -n "${PLEXSERVER}" -a "${AUTOINSTALL}" = "yes" ]; then
 fi
 
 if [ "${AUTOINSTALL}" = "yes" ]; then
-	if ! hash ldconfig 2>/dev/null && [ "${REDHAT}" = "no" ]; then
+	if ! hash ldconfig 2>/dev/null && [ "${DISTRO}" != "redhat" ]; then
 		export PATH=$PATH:/sbin
 	fi
 
@@ -509,7 +507,7 @@ if [ "${AUTODELETE}" = "yes" ]; then
 fi
 
 if [ "${AUTOSTART}" = "yes" ]; then
-	if [ "${REDHAT}" = "no" ]; then
+	if [ "${DISTRO}" != "redhat" ]; then
 		warn "The AUTOSTART [-s] option may not be needed on your distribution."
 	fi
 	# Check for systemd

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -307,6 +307,20 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 			else
 				DISTRO_INSTALL="${REDHAT_INSTALL}"
 			fi
+		elif [ -f /etc/synoinfo.conf ]; then
+		        DISTRO="synology"
+		        if [ "${PUBLIC}" = "yes" ]; then
+			        if [ "${ARCH}" = "x86_64"]; then
+				    BUILD="linux-ubuntu-x86_64"
+				elif [ "${ARCH}" = "x86"]; then
+				    BUILD="linux-synology-i686"
+				elif [ "${ARCH}" = "armv7"]; then
+				    BUILD="linux-synology-armv7"
+				fi
+			else
+				BUILD="linux-${ARCH}"
+			fi
+			DISTRO_INSTALL="synopkg install"
 		else
 			REDHAT=no
 			DISTRO="debian"

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -510,7 +510,7 @@ if [ "${AUTODELETE}" = "yes" ]; then
 fi
 
 if [ "${AUTOSTART}" = "yes" ]; then
-	if [ "${DISTRO}" != "redhat" ]; then
+	if [ "${DISTRO}" != "redhat" -a "${DISTRO}" != "synology" ]; then
 		warn "The AUTOSTART [-s] option may not be needed on your distribution."
 	fi
 	# Check for systemd

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -494,7 +494,7 @@ if [ "${AUTOINSTALL}" = "yes" ]; then
 		# Clarify why this failed, so user won't be left in the dark
 		error "Failed to install update. Command '${DISTRO_INSTALL} "${DOWNLOADDIR}/${FILENAME}"' returned error code ${RET}"
 		if [ "${DISTRO}" = "synology" -a ${RET} -eq 1 ]; then
-			echo -e "On Synology devices, you need to add Plex's public key to Package Center. If you have not done so, follow the instructions at \033[0;34mhttps://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/\033[0m"
+			error "On Synology devices, you need to add Plex's public key to Package Center. If you have not done so, follow the instructions at https://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/"
 		fi
 		exit ${RET}
 	fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -493,6 +493,9 @@ if [ "${AUTOINSTALL}" = "yes" ]; then
 	if [ ${RET} -ne 0 ]; then
 		# Clarify why this failed, so user won't be left in the dark
 		error "Failed to install update. Command '${DISTRO_INSTALL} "${DOWNLOADDIR}/${FILENAME}"' returned error code ${RET}"
+		if [ "${DISTRO}" = "synology" -a ${RET} -eq 1 ]; then
+			info "On Synology devices, you need to add Plex's public key to Package Center. If you have not done so, follow the instructions at \033[0;34mhttps://support.plex.tv/articles/205165858-how-to-add-plex-s-package-signing-public-key-to-synology-nas-package-center/\033[0m"
+		fi
 		exit ${RET}
 	fi
 fi

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -309,7 +309,6 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 			fi
 		elif [ -f /etc/synoinfo.conf ]; then
 			DISTRO="synology"
-			BUILD="linux-${ARCH}"
 			DISTRO_INSTALL="synopkg install"
 		else
 			REDHAT=no

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -520,6 +520,8 @@ if [ "${AUTOSTART}" = "yes" ]; then
 		service plexmediaserver start
 	elif [ -x /etc/init.d/plexmediaserver ]; then
 		/etc/init.d/plexmediaserver start
+	elif [ "${DISTRO}" = "synology" ]; then
+		synopkg start "Plex Media Server"
 	else
 		error "AUTOSTART was specified but no startup scripts were found for 'plexmediaserver'."
 		exit 1

--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -310,11 +310,11 @@ if [ -z "${DISTRO_INSTALL}" ]; then
 		elif [ -f /etc/synoinfo.conf ]; then
 		        DISTRO="synology"
 		        if [ "${PUBLIC}" = "yes" ]; then
-			        if [ "${ARCH}" = "x86_64"]; then
+			        if [ "${ARCH}" = "x86_64" ]; then
 				    BUILD="linux-ubuntu-x86_64"
-				elif [ "${ARCH}" = "x86"]; then
+				elif [ "${ARCH}" = "x86" ]; then
 				    BUILD="linux-synology-i686"
-				elif [ "${ARCH}" = "armv7"]; then
+				elif [ "${ARCH}" = "armv7" ]; then
 				    BUILD="linux-synology-armv7"
 				fi
 			else


### PR DESCRIPTION
This builds on #247 to support changes in DSM7

- A new build id: `synology-dsm7`
- The package name has changed to `PlexMediaServer` (spaces removed)
- `systemctl` command is available on DSM7, so conditionals for finding the start command to run needed to be reordered