### PR TITLE
Added sudo as a dependency

### DIFF
--- a/extras/installer.sh
+++ b/extras/installer.sh
@@ -324,7 +324,7 @@ elif [ ! -z "$SUDO_USER" ]; then
 	abort "This script will ask for sudo as necessary, but you should not run it as sudo. Please try again."
 fi
 
-for req in wget git; do
+for req in wget git sudo; do
 	if ! hash $req 2>/dev/null; then
 		install $req
 	fi


### PR DESCRIPTION
When running the installer.sh on an LXC Debian 10 container (Proxmox 7) the script fails due to the lack of sudo package. Added sudo package to the dependency check.